### PR TITLE
Support clima and new-central at the same time

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,5 +1,4 @@
 agents:
-  queue: new-central
   slurm_mem: 8G
   modules: climacommon/2024_04_05
 


### PR DESCRIPTION
This works by changing the init step in buildkite to:
```yml
steps:
  - command: "buildkite-agent pipeline upload"
    label: ":pipeline:"
    if: "! build.pull_request.labels includes \"Run on clima\""
    agents:
      queue: new-central
  - command: "buildkite-agent pipeline upload"
    label: ":pipeline:"
    if: "build.pull_request.labels includes \"Run on clima\""
    agents:
      queue: clima
```