### PR TITLE
add default regridder_type

### DIFF
--- a/docs/src/datahandling.md
+++ b/docs/src/datahandling.md
@@ -43,7 +43,7 @@ the `NCFileReader`.
 
 > This extension is loaded when loading `ClimaCore` and `NCDatasets` are loaded.
 > In addition to this, a `Regridder` is needed (which might require importing
-> additional packages).
+> additional packages) - see [`Regridders`](@ref) for more information.
 
 ## Example
 

--- a/docs/src/regridders.md
+++ b/docs/src/regridders.md
@@ -21,6 +21,10 @@ Currently, `Regridders` comes with two implementations:
 > everything that is needed to read a file to the model grid (internally using
 > the `Regridders`).
 
+If a regridder type is not specified by the user, and multiple are available,
+the `InterpolationsRegridder` will be used by default. At least one regridder
+extension must be loaded to be able to use regridding.
+
 ## `TempestRegridder`
 
 > This extension is loaded when loading `ClimaCoreTempestRemap`

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -82,7 +82,7 @@ end
                 target_space::ClimaCore.Spaces.AbstractSpace;
                 reference_date::Dates.DateTime = Dates.DateTime(1979, 1, 1),
                 t_start::AbstractFloat = 0.0,
-                regridder_type = :TempestRegridder)
+                regridder_type = nothing)
 
 Create a `DataHandler` to read `varname` from `file_path` and remap it to `target_space`.
 
@@ -112,6 +112,8 @@ everything more type stable.)
                     `:InterpolationsRegridder` (using `Interpolations.jl`). `TempestRemap`
                     regrids everything ahead of time and saves the result to HDF5 files.
                     `Interpolations.jl` is online and GPU compatible but not conservative.
+                    If the regridder type is not specified by the user, and multiple are
+                    available, the default `:InterpolationsRegridder` regridder is used.
 """
 function DataHandling.DataHandler(
     file_path::AbstractString,
@@ -119,8 +121,13 @@ function DataHandling.DataHandler(
     target_space::ClimaCore.Spaces.AbstractSpace;
     reference_date::Dates.DateTime = Dates.DateTime(1979, 1, 1),
     t_start::AbstractFloat = 0.0,
-    regridder_type = :TempestRegridder,
+    regridder_type = nothing,
 )
+
+    # Determine which regridder to use if not already specified
+    regridder_type =
+        isnothing(regridder_type) ? Regridders.default_regridder_type() :
+        regridder_type
 
     # File reader, deals with ingesting data, possibly buffered/cached
     file_reader = NCFileReader(file_path, varname)

--- a/ext/SpaceVaryingInputsExt.jl
+++ b/ext/SpaceVaryingInputsExt.jl
@@ -145,7 +145,7 @@ function SpaceVaryingInputs.SpaceVaryingInput(
     file_path,
     varname,
     target_space;
-    regridder_type = :TempestRegridder,
+    regridder_type = nothing,
 )
     return SpaceVaryingInputs.SpaceVaryingInput(
         DataHandler(file_path, varname, target_space; regridder_type),

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -111,7 +111,7 @@ function TimeVaryingInputs.TimeVaryingInput(
     method = LinearInterpolation(),
     reference_date::Dates.DateTime = Dates.DateTime(1979, 1, 1),
     t_start::AbstractFloat = 0.0,
-    regridder_type = :TempestRegridder,
+    regridder_type = nothing,
 )
     data_handler = DataHandling.DataHandler(
         file_path,

--- a/src/Regridders.jl
+++ b/src/Regridders.jl
@@ -11,6 +11,8 @@ The key function exposed by `Regridders` is the `regrid` method.
 """
 module Regridders
 
+import ..ClimaUtilities
+
 # When adding a new regridder, you also have to change some functions in the DataHandler
 # module. Find where :TempestRegridder is used.
 abstract type AbstractRegridder end
@@ -20,5 +22,29 @@ function TempestRegridder end
 function InterpolationsRegridder end
 
 function regrid end
+
+"""
+    default_regridder_type()
+
+Return the type of regridder to be used if the user doesn't specify one.
+This function returns the first available regridder in the following order:
+  - InterpolationsRegridder
+  - TempestRegridder
+based on which regridder(s) are currently loaded.
+"""
+function default_regridder_type()
+    # Use InterpolationsRegridder if available
+    if !isnothing(
+        Base.get_extension(ClimaUtilities, :InterpolationsRegridderExt),
+    )
+        regridder_type = :InterpolationsRegridder
+        # If InterpolationsRegridder isn't available, and TempestRegridder is, use TempestRegridder
+    elseif !isnothing(Base.get_extension(ClimaUtilities, :TempestRegridderExt))
+        regridder_type = :TempestRegridder
+    else
+        error("No regridder available")
+    end
+    return regridder_type
+end
 
 end

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -6,9 +6,25 @@ import ClimaUtilities: Regridders
 import ClimaCore
 import ClimaComms
 
-import Interpolations
-
 include("TestTools.jl")
+
+@testset "default_regridder_type" begin
+    # Case 1: no regridder available
+    @test_throws ErrorException Regridders.default_regridder_type()
+
+    # Case 2: only TempestRegridder available
+    import ClimaCoreTempestRemap
+    @test Regridders.default_regridder_type() == :TempestRegridder
+
+    # Case 3: TempestRegridder and InterpolationsRegridder both available
+    import Interpolations
+    @test Regridders.default_regridder_type() == :InterpolationsRegridder
+
+    # Case 4: only TempestRegridder available
+    # This case is not currently tested because we don't have a way to remove
+    #  previously-loaded extensions.
+end
+
 
 @testset "InterpolationsRegridder" begin
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
closes #23 

## Content
- Add function `get_regridder_type` to Regridders.jl. This will check which package extensions are loaded and select a regridder to use based on that. By default, interpolation will be used
- Use `get_regridder_type` in DataHandlingExt if regridder type is not supplied by user
- Add tests
  - Note: Tests for 3/4 cases are implemented. I don't think there's a way to clear packages/extensions that are loaded, which we would need to do to check each of the cases of different regridders being available.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
