### PR TITLE
outfile_root on all pids

### DIFF
--- a/ext/TempestRegridderExt.jl
+++ b/ext/TempestRegridderExt.jl
@@ -76,12 +76,12 @@ function Regridders.TempestRegridder(
 )
     space = target_space
     comms_ctx = ClimaComms.context(space)
+    outfile_root = varname
 
     if ClimaComms.iamroot(comms_ctx)
         @info "Saving TempestRegrid files to $regrid_dir"
 
         FT = ClimaCore.Spaces.undertype(space)
-        outfile_root = varname
         varnames = [varname]
 
         hdwrite_regridfile_rll_to_cgll(

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -12,6 +12,7 @@ import ClimaCoreTempestRemap
 using NCDatasets
 
 const context = ClimaComms.context()
+@info context
 
 @testset "DataHandler, static" begin
     PATH = joinpath(


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Create `outfile_root` on all pids, so we can use TempestRegridder on MPI. Also displays `context` in the data_handling test, which will be helpful to ensure we're running on the architecture we expect.
