### PR TITLE
Fix MPI and distributed filesystem (for real this time)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
         version:
           - '1.9'
           - '1.10'
+          - '~1.11.0-0'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/test/clima_artifacts.jl
+++ b/test/clima_artifacts.jl
@@ -21,6 +21,8 @@ import ClimaComms
 const context = ClimaComms.context()
 ClimaComms.init(context)
 
+let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.2)
+
 expected_path = artifact"socrates"
 
 # Remove the artifact, so that we test that we are downloading it
@@ -36,6 +38,8 @@ Base.Filesystem.rm(expected_path, recursive = true)
 
     # Test with name as a variable
     Base.Filesystem.rm(expected_path, recursive = true)
+    ClimaComms.barrier(context)
+    let_filesystem_catch_up()
     artifact_name = "socrates"
 
     @test ClimaArtifacts.@clima_artifact(artifact_name, context) ==

--- a/test/output_path_generator.jl
+++ b/test/output_path_generator.jl
@@ -7,7 +7,7 @@ using Test
 const context = ClimaComms.context()
 ClimaComms.init(context)
 
-let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.1)
+let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.2)
 
 @testset "RemovePrexistingStyle" begin
     base_output_path = ClimaComms.iamroot(context) ? mktempdir() : ""
@@ -22,7 +22,7 @@ let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.1)
         context = context,
         style = RemovePreexistingStyle(),
     )
-    let_filesystem_catch_up()
+
     # Check that it exists now
     @test isdir(output_path)
 
@@ -42,7 +42,7 @@ let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.1)
         context = context,
         style = RemovePreexistingStyle(),
     )
-    let_filesystem_catch_up()
+
     @test !isfile(joinpath(output_path, "something"))
 
     Base.rm(base_output_path, force = true, recursive = true)
@@ -62,7 +62,7 @@ end
 
     @test expected_output ==
           generate_output_path(output_path, context = context)
-    let_filesystem_catch_up()
+
     # Check that it exists now
     @test isdir(output_path)
 
@@ -75,14 +75,12 @@ end
     # Now the folder exists, let us see if the rotation works
     @test expected_output ==
           generate_output_path(output_path, context = context)
-    let_filesystem_catch_up()
 
     # Check folder output_0001 was created
     @test isdir(joinpath(output_path, "output_0001"))
 
     # Check link points to new folder
     @test readlink(expected_output) == "output_0001"
-    let_filesystem_catch_up()
 
     # Now let us check something wrong
 
@@ -96,7 +94,6 @@ end
         output_path,
         context = context,
     )
-    let_filesystem_catch_up()
     # Wrong link
     if ClimaComms.iamroot(context)
         wrong_dir = joinpath(output_path, "wrong")
@@ -104,7 +101,6 @@ end
         symlink(wrong_dir, expected_output, dir_target = true)
     end
     ClimaComms.barrier(context)
-    let_filesystem_catch_up()
     @test_throws ErrorException generate_output_path(
         output_path,
         context = context,


### PR DESCRIPTION
This PR adds a wait time for certain operations. This is relavent on distributed filesystems, where it can take a little bit of time to propagate that a folder was created/destroyed.

It also adds a test for Julia 1.11.

Closes #38 