### PR TITLE
Fix MPI test 

### DIFF
--- a/test/clima_artifacts.jl
+++ b/test/clima_artifacts.jl
@@ -37,7 +37,7 @@ Base.Filesystem.rm(expected_path, recursive = true)
     @test ClimaArtifacts.@clima_artifact("socrates", context) == expected_path
 
     # Test with name as a variable
-    Base.Filesystem.rm(expected_path, recursive = true)
+    Base.Filesystem.rm(expected_path, force = true, recursive = true)
     ClimaComms.barrier(context)
     let_filesystem_catch_up()
     artifact_name = "socrates"


### PR DESCRIPTION
https://buildkite.com/clima/climautilities-ci/builds/127#018efc0a-213e-406b-a629-e676dd2657d1

The issue is that some MPI processes could run `rm` on a filesystem without the socrates file. By forcing it, all the MPI processes will be able to run `rm` without complaining if no file is there.