### PR TITLE
Fix compatibility with ClimaComms 0.6

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 agents:
   queue: new-central
   slurm_mem: 8G
-  modules: climacommon/2024_04_05
+  modules: climacommon/2024_04_30
 
 env:
   JULIA_LOAD_PATH: "${JULIA_LOAD_PATH}:${BUILDKITE_BUILD_CHECKOUT_PATH}/.buildkite"

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+v0.1.7
+------
+
+- Fix compatibility with ClimaComms 0.6. PR [#54](https://github.com/CliMA/ClimaUtilities.jl/pull/54)
+
 v0.1.6
 -------
 - `OutputPathGenerator` now tries to create an active link when one is not available but some data is already there [#50](https://github.com/CliMA/ClimaUtilities.jl/pull/50)

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.6"
+version = "0.1.7"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
@@ -12,10 +12,12 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaCoreTempestRemap = "d934ef94-cdd4-4710-83d6-720549644b70"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 
 [extensions]
+CUDAUtilsExt = ["ClimaCore", "CUDA"]
 DataHandlingExt = ["ClimaCore", "NCDatasets"]
 InterpolationsRegridderExt = ["Interpolations", "ClimaCore"]
 MPIUtilsExt = "ClimaComms"
@@ -31,6 +33,7 @@ Artifacts = "1"
 ClimaComms = "0.5, 0.6"
 ClimaCore = "0.11, 0.12, 0.13, 0.14"
 ClimaCoreTempestRemap = "0.3"
+CUDA = "4, 5"
 Dates = "1"
 Interpolations = "0.15"
 NCDatasets = "0.13, 0.14"

--- a/ext/CUDAUtilsExt.jl
+++ b/ext/CUDAUtilsExt.jl
@@ -1,0 +1,31 @@
+module CUDAUtilsExt
+
+import ClimaCore: ClimaComms
+import ClimaUtilities
+import ClimaUtilities.TimeVaryingInputs
+import CUDA
+
+function TimeVaryingInputs.evaluate!(
+    device::ClimaComms.CUDADevice,
+    destination,
+    itp,
+    time,
+    args...;
+    kwargs...,
+)
+    # Cannot do type dispatch across extensions, we check here
+    @assert itp isa
+            Base.get_extension(
+        ClimaUtilities,
+        :TimeVaryingInputs0DExt,
+    ).InterpolatingTimeVaryingInput0D
+    CUDA.@cuda TimeVaryingInputs.evaluate!(
+        parent(destination),
+        itp,
+        time,
+        itp.method,
+    )
+    return nothing
+end
+
+end

--- a/test/TestTools.jl
+++ b/test/TestTools.jl
@@ -1,8 +1,6 @@
 import ClimaCore
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 
 function make_spherical_space(FT; context = ClimaComms.context())
     radius = FT(128)

--- a/test/clima_artifacts.jl
+++ b/test/clima_artifacts.jl
@@ -17,9 +17,7 @@ expected_path2 = artifact"laskar2004"
 end
 
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 
 const context = ClimaComms.context()
 ClimaComms.init(context)

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -8,9 +8,7 @@ import ClimaUtilities.DataHandling
 import ClimaCore
 import ClimaComms
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 import Interpolations as Intp
 import ClimaCoreTempestRemap
 using NCDatasets

--- a/test/output_path_generator.jl
+++ b/test/output_path_generator.jl
@@ -1,9 +1,7 @@
 import ClimaUtilities.OutputPathGenerator:
     generate_output_path, RemovePreexistingStyle, ActiveLinkStyle
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 import Base: rm
 using Test
 

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -5,9 +5,7 @@ import ClimaUtilities: Regridders
 
 import ClimaCore
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 
 const context = ClimaComms.context()
 ClimaComms.init(context)

--- a/test/space_varying_inputs.jl
+++ b/test/space_varying_inputs.jl
@@ -5,9 +5,8 @@ using ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 
 using ClimaCore
 using Interpolations
-@static if pkgversion(ClimaCore.ClimaComms) >= v"0.6"
-    ClimaCore.ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaCore.ClimaComms) >= v"0.6" &&
+        ClimaCore.ClimaComms.@import_required_backends
 
 const context = ClimaCore.ClimaComms.context()
 ClimaCore.ClimaComms.init(context)

--- a/test/space_varying_inputs.jl
+++ b/test/space_varying_inputs.jl
@@ -3,13 +3,13 @@ using Test
 import ClimaUtilities
 using ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 using ClimaCore
 using Interpolations
-@static pkgversion(ClimaCore.ClimaComms) >= v"0.6" &&
-        ClimaCore.ClimaComms.@import_required_backends
 
-const context = ClimaCore.ClimaComms.context()
-ClimaCore.ClimaComms.init(context)
+const context = ClimaComms.context()
+ClimaComms.init(context)
 
 include("TestTools.jl")
 

--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -8,9 +8,7 @@ import ClimaUtilities: TimeVaryingInputs
 
 import ClimaCore: Domains, Geometry, Fields, Meshes, Topologies, Spaces
 import ClimaComms
-@static if pkgversion(ClimaComms) >= v"0.6"
-    ClimaComms.@import_required_backends
-end
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 
 import Interpolations
 import NCDatasets


### PR DESCRIPTION
Prior to this commit, the macro CUDA.@cuda was still being parsed, leading to failures when CUDA was not available. I tried adding another `@static` to protect this evaluation, but found that it doesn't work because `Base.get_extension(ClimaComms, :ClimaCommsCUDAExt`) is `nothing`. The reason for this is, I think, `@static` runs at the macro-expansion phase, so when the conditional for `@static` is evaluated, `CUDA` has not been imported yet because `CUDA` is imported with another macro (`ClimaComms.@import_required_backends`). 

The solution I came up with is to put CUDA in an extension for `ClimaUtilities`. This works, but it is a little bit dissatisfying for two reasons. Given that extensions cannot easily use types across each other, I could not add a dispatch over the correct type. Second, ideally, `ClimaUtilities` should be backend-agnostic, so maybe it is up to `ClimaComms` to implement a way to launch kernels.

Closes #51 

Tested in ClimaLand: https://buildkite.com/clima/climaland-ci/builds/3892