### PR TITLE
Do not allow empty output_path

### DIFF
--- a/src/OutputPathGenerator.jl
+++ b/src/OutputPathGenerator.jl
@@ -110,6 +110,7 @@ function generate_output_path(
     context = nothing,
     style = ActiveLinkStyle(),
 )
+    output_path == "" && error("output_path cannot be empty")
     return generate_output_path(style, output_path; context)
 end
 

--- a/src/OutputPathGenerator.jl
+++ b/src/OutputPathGenerator.jl
@@ -64,6 +64,11 @@ This style generates a unique output path within a base directory specified by
 Additionally, it manages a sequence of subfolders and a symbolic link named "output_active"
 for convenient access to the active output location.
 
+This style is designed to:
+- be non-destructive,
+- provide a deterministic and fixed path for the latest available data,
+- and have nearly zero runtime overhead.
+
 # Examples:
 
 Let us assume that `output_path = dormouse`.

--- a/test/output_path_generator.jl
+++ b/test/output_path_generator.jl
@@ -11,6 +11,12 @@ ClimaComms.init(context)
 let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.2)
 
 @testset "RemovePrexistingStyle" begin
+    # Test empty output_path
+    @test_throws ErrorException generate_output_path(
+        "",
+        style = RemovePreexistingStyle(),
+    )
+
     base_output_path = ClimaComms.iamroot(context) ? mktempdir() : ""
     base_output_path = ClimaComms.bcast(context, base_output_path)
     ClimaComms.barrier(context)
@@ -51,6 +57,9 @@ let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.2)
 end
 
 @testset "ActiveLinkStyle" begin
+    # Test empty output_path
+    @test_throws ErrorException generate_output_path("")
+
     base_output_path = ClimaComms.iamroot(context) ? mktempdir() : ""
     base_output_path = ClimaComms.bcast(context, base_output_path)
     ClimaComms.barrier(context)


### PR DESCRIPTION
This PR explicitely disallows empty `output_path`s in `generate_output_path` for the `ActiveLinkStyle`. Previously, this input was not handled correctly: when `""` was passed, a slash would be added, so that `generate_output_path` tried writing to `/output_0000`, which is read-only. Now, we inform the user that their input is invalid.

Fixes #56 


