### PR TITLE
Use NTFS junction points when symlinks cannot be created on Windows

### DIFF
--- a/docs/src/outputpathgenerator.md
+++ b/docs/src/outputpathgenerator.md
@@ -53,6 +53,14 @@ Let's assume your `output_path` is set to `data`.
   none are found, it creates `data/output_0000` and a link `data/output_active`
   pointing to it.
 
+#### A note for Windows users
+
+Windows does not always allow the creation of symbolic links by unprivileged
+users, so some details about links might be slightly different depending on your
+system. If you are using Windows, please have a look at docstring on the
+`ActiveLinkStyle` to learn more about possible differences.
+
+
 ## API
 
 ```@docs

--- a/src/OutputPathGenerator.jl
+++ b/src/OutputPathGenerator.jl
@@ -77,6 +77,16 @@ Let us assume that `output_path = dormouse`.
 - `dormouse` exists and does not contain a `output_active`, `ActiveLinkStyle` will check if
   any `dormouse/output_XXXX` exists. If not, it creates `dormouse/output_0000` and a link
   `dormouse/output_active` that points to this directory.
+
+## A note for Windows users
+
+Windows does not always allow the creation of symbolic links by unprivileged users. This
+depends on the version of Windows, but also some of its settings. When the creation of
+symbolic links is not possible, `OutputPathGenerator` will create NTFS junction points
+instead. Junction points are similar to symbolic links, with the main difference that they
+have to refer to directories and they have to be absolute paths. As a result, on systems
+that do not allow unprivileged users to create symbolic links, moving the base output folder
+results in breaking the `output_active` link.
 """
 struct ActiveLinkStyle end
 
@@ -209,8 +219,23 @@ function generate_output_path(::ActiveLinkStyle, output_path; context = nothing)
     # Make new folder
     if root_or_singleton(context)
         mkpath(new_output_folder)
-        # In Windows, symlinks must be explicitly declared as referring to a directory or not
-        symlink("output_$next_counter_str", active_link, dir_target = true)
+        # On Windows, creating symlinks might require admin privileges. This depends on the
+        # version of Windows and some of its settings (e.g., if "Developer Mode" is enabled).
+        # So, we first try creating a symlink. If this fails, we resort to creating a NTFS
+        # junction. This is almost the same as a symlink, except it requires absolute paths.
+        # In general, relative paths would be preferable because they make the output
+        # completely relocatable (whereas absolute paths are not).
+        try
+            symlink("output_$next_counter_str", active_link, dir_target = true)
+        catch e
+            if e isa Base.IOError && Base.uverrorname(e.code) == "EPERM"
+                active_link = abspath(active_link)
+                dest_active_link = abspath("output_$next_counter_str")
+                symlink(dest_active_link, active_link, dir_target = true)
+            else
+                rethrow(e)
+            end
+        end
     end
     maybe_wait_filesystem(context, new_output_folder)
     return active_link


### PR DESCRIPTION
Windows does not always allow the creation of symbolic links by unprivileged users. This depends on the version of Windows, but also some of its settings. When the creation of symbolic links is not possible, `OutputPathGenerator` will create NTFS junction points instead. Junction points are similar to symbolic links, with the main difference that they
have to refer to directories and they have to be absolute paths. As a result, on systems that do not allow unprivileged users to create symbolic links, moving the base output folder results in breaking the `output_active` link.

Note, I have no way to test if this code is valid besides relying on the CI runners. Additional validation would be helpful.

As a reference, here is the docstring for `symlink`:
```julia
  symlink(target::AbstractString, link::AbstractString; dir_target = false)

  Creates a symbolic link to target with the name link.

  On Windows, symlinks must be explicitly declared as referring to a directory
  or not. If target already exists, by default the type of link will be auto-
  detected, however if target does not exist, this function defaults to
  creating a file symlink unless dir_target is set to true. Note that if the
  user sets dir_target but target exists and is a file, a directory symlink
  will still be created, but dereferencing the symlink will fail, just as if
  the user creates a file symlink (by calling symlink() with dir_target set to
  false before the directory is created) and tries to dereference it to a
  directory.

  Additionally, there are two methods of making a link on Windows; symbolic
  links and junction points. Junction points are slightly more efficient, but
  do not support relative paths, so if a relative directory symlink is
  requested (as denoted by isabspath(target) returning false) a symlink will
  be used, else a junction point will be used. Best practice for creating
  symlinks on Windows is to create them only after the files/directories they
  reference are already created.

  See also: hardlink.

  │ Note
  │
  │  This function raises an error under operating systems that do not
  │  support soft symbolic links, such as Windows XP.

  │ Julia 1.6
  │
  │  The dir_target keyword argument was added in Julia 1.6. Prior to
  │  this, symlinks to nonexistent paths on windows would always be
  │  file symlinks, and relative symlinks to directories were not
  │  supported.
```

Fixes #52 
