### PR TITLE
Add warning about climaartifacts

### DIFF
--- a/docs/src/climaartifacts.md
+++ b/docs/src/climaartifacts.md
@@ -75,6 +75,10 @@ The `@clima_artifact` macro is executed at parse time when the argument is a
 literal string (e.g., `@clima_artifact("socrates")`), and at runtime when it is
 a variable `@clima_artifact(artifact_name)`.
 
+> Note: `context` is a positional argument, not a keyword one. Calling
+> `@clima_artifact("socrates"; context)` will fail. (This is due to how Julia
+> macros handle keyword arguments)
+
 ### Tagging artifacts
 
 A full climate simulation requires lots of external input data. Most of this

--- a/src/ClimaArtifacts.jl
+++ b/src/ClimaArtifacts.jl
@@ -34,6 +34,10 @@ other wait until the file is fully downloaded.
 Passing the context is required only for lazy artifacts.
 """
 macro clima_artifact(name, context = nothing)
+
+    # Note, we do not handle the case with clima_artifact(name; context)
+    # See, https://github.com/CliMA/ClimaUtilities.jl/pull/62
+
     # Find Artifacts.toml file we're going to load from
     srcfile = string(__source__.file)
     if (


### PR DESCRIPTION
Julia handles keyword arguments passed with ; in a special way. According to goerz, keyword arguments passed with ; are moved to the front of the macro call. So, we have to handle this case separately
    https://discourse.julialang.org/t/documentation-for-how-macros-handle-keyword-arguments/88009
    
We have to support three cases:
1. context is a ClimaComms.context
2. context is an expression that sets :context = value
3. name (!) is an expression that contains parameters that set the context

The easiest way to go about learning about this is writing a simple macro

    macro mymacrotest(first, second)
        println("First value: ", first)
        println("First type: ", typeof(first))
        println("Second value: ", second)
        println("Second type: ", typeof(second))
    end

Then, test this with the four inputs

    @mymacrotest("First", "Second")
    @mymacrotest("First", second = "Second")
    @mymacrotest("First"; second = "Second")
    second = "Second"; @mymacrotest("First"; second)
    
The unexpected inputs are last two:

    First value: $(Expr(:parameters, :($(Expr(:kw, :second, "Second")))))
    First type: Expr
    Second value: First
    Second type: String
    
And

    First value: $(Expr(:parameters, :second))
    First type: Expr
    Second value: First
    Second type: String


I tried supporting all of this but it became a mess, so I figured that the simplest thing is to just declare that `context` has to be positional.