### PR TITLE
Reorder extensions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+v0.1.9
+------
+
+- Extensions are internally reorganized, removing precompilation errors. PR
+  [#69](https://github.com/CliMA/ClimaUtilities.jl/pull/69)
+
 v0.1.8
 ------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.8"
+version = "0.1.9"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/Project.toml
+++ b/Project.toml
@@ -9,31 +9,29 @@ Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
 
 [weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaComms = "3a4d1b5c-c61d-41fd-a00a-5873ba7a1b0d"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaCoreTempestRemap = "d934ef94-cdd4-4710-83d6-720549644b70"
-CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 
 [extensions]
-CUDAUtilsExt = ["ClimaCore", "CUDA"]
-DataHandlingExt = ["ClimaCore", "NCDatasets"]
-InterpolationsRegridderExt = ["Interpolations", "ClimaCore"]
-MPIUtilsExt = "ClimaComms"
-NCFileReaderExt = "NCDatasets"
-SpaceVaryingInputsExt = ["ClimaCore", "NCDatasets"]
-TempestRegridderExt = "ClimaCoreTempestRemap"
-TimeVaryingInputs0DExt = "ClimaCore"
-TimeVaryingInputsExt = ["ClimaCore", "NCDatasets"]
+ClimaUtilitiesClimaCoreExt = "ClimaCore"
+ClimaUtilitiesClimaCoreInterpolationsExt = ["ClimaCore", "Interpolations"]
+ClimaUtilitiesClimaCoreNCDatasetsExt = ["ClimaCore", "NCDatasets"]
+ClimaUtilitiesNCDatasetsExt = "NCDatasets"
+ClimaUtilitiesClimaCommsCUDAExt = ["ClimaComms", "CUDA"]
+ClimaUtilitiesClimaCommsExt = "ClimaComms"
+ClimaUtilitiesClimaCoreTempestRemapExt = "ClimaCoreTempestRemap"
 
 [compat]
 Adapt = "3.3, 4"
 Artifacts = "1"
+CUDA = "5"
 ClimaComms = "0.5.6, 0.6"
 ClimaCore = "0.12, 0.13, 0.14"
 ClimaCoreTempestRemap = "0.3.13"
-CUDA = "5"
 Dates = "1"
 Interpolations = "0.15"
 NCDatasets = "0.13.1, 0.14"

--- a/README.md
+++ b/README.md
@@ -39,6 +39,18 @@ it should not depend on any package outside of the standard library and should
 have negligible import costs. To accomplish this, everything is implemented in
 Julia extensions.
 
+Extensions are organized in the following way. The extensions defined in the
+`Project.toml` are defined in terms of the packages they require to be loaded.
+This avoids circular dependencies among extensions. Each of these extensions
+`include`s modules that match what is defined in `src`.
+
+For example, `ClimaUtilitiesClimaCoreNCDatasetsExt` is loaded when `ClimaCore`
+and `NCDatasets` are loaded. Internally, `ClimaUtilitiesClimaCoreNCDatasetsExt`
+loads `DataHandlingExt.jl`, `SpaceVaryingInputsExt.jl`, and
+`TimeVaryingInputsExt.jl`. Each of them implements methods defined in
+`src/DataHandling.jl`, `src/SpaceVaryingInputs.jl`, and
+`src/TimeVaryingInputs.jl` respectively
+
 ### Tests and environments
 
 We prioritize well-tested code to guarantee `ClimaUtilities.jl` functions
@@ -75,7 +87,7 @@ used by our Buildkite pipeline.
 
 #### Running tests
 
-There are two equivalent ways to run tests. 
+There are two equivalent ways to run tests.
 
 First, Start a Julia session in the `ClimaUtilities` directory:
 ``` sh
@@ -83,7 +95,7 @@ julia --project
 ```
 Enter `Pkg` mode by typing `]`. This will change the prompt. Run `test`.
 
-Equivalently, you can run 
+Equivalently, you can run
 ``` sh
 julia --project=test tests/runtests.jl
 ```

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -44,14 +44,17 @@ makedocs(
     clean = true,
     modules = [
         ClimaUtilities,
-        Base.get_extension(ClimaUtilities, :DataHandlingExt),
-        Base.get_extension(ClimaUtilities, :InterpolationsRegridderExt),
-        Base.get_extension(ClimaUtilities, :MPIUtilsExt),
-        Base.get_extension(ClimaUtilities, :NCFileReaderExt),
-        Base.get_extension(ClimaUtilities, :SpaceVaryingInputsExt),
-        Base.get_extension(ClimaUtilities, :TempestRegridderExt),
-        Base.get_extension(ClimaUtilities, :TimeVaryingInputs0DExt),
-        Base.get_extension(ClimaUtilities, :TimeVaryingInputsExt),
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesClimaCoreExt),
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreInterpolationsExt,
+        ),
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreNCDatasetsExt,
+        ),
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt),
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesClimaCommsExt),
     ],
 )
 

--- a/ext/ClimaUtilitiesClimaCommsCUDAExt.jl
+++ b/ext/ClimaUtilitiesClimaCommsCUDAExt.jl
@@ -1,6 +1,6 @@
-module CUDAUtilsExt
+module ClimaUtilitiesClimaCommsCUDAExt
 
-import ClimaCore: ClimaComms
+import ClimaComms
 import ClimaUtilities
 import ClimaUtilities.TimeVaryingInputs
 import CUDA
@@ -17,8 +17,8 @@ function TimeVaryingInputs.evaluate!(
     @assert itp isa
             Base.get_extension(
         ClimaUtilities,
-        :TimeVaryingInputs0DExt,
-    ).InterpolatingTimeVaryingInput0D
+        :ClimaUtilitiesClimaCoreExt,
+    ).TimeVaryingInputs0DExt.InterpolatingTimeVaryingInput0D
     CUDA.@cuda TimeVaryingInputs.evaluate!(
         parent(destination),
         itp,

--- a/ext/ClimaUtilitiesClimaCommsExt.jl
+++ b/ext/ClimaUtilitiesClimaCommsExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesClimaCommsExt
+
+include("MPIUtilsExt.jl")
+
+end

--- a/ext/ClimaUtilitiesClimaCoreExt.jl
+++ b/ext/ClimaUtilitiesClimaCoreExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesClimaCoreExt
+
+include("TimeVaryingInputs0DExt.jl")
+
+end

--- a/ext/ClimaUtilitiesClimaCoreInterpolationsExt.jl
+++ b/ext/ClimaUtilitiesClimaCoreInterpolationsExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesClimaCoreInterpolationsExt
+
+include("InterpolationsRegridderExt.jl")
+
+end

--- a/ext/ClimaUtilitiesClimaCoreNCDatasetsExt.jl
+++ b/ext/ClimaUtilitiesClimaCoreNCDatasetsExt.jl
@@ -1,0 +1,7 @@
+module ClimaUtilitiesClimaCoreNCDatasetsExt
+
+include("DataHandlingExt.jl")
+include("SpaceVaryingInputsExt.jl")
+include("TimeVaryingInputsExt.jl")
+
+end

--- a/ext/ClimaUtilitiesClimaCoreTempestRemapExt.jl
+++ b/ext/ClimaUtilitiesClimaCoreTempestRemapExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesClimaCoreTempestRemapExt
+
+include("TempestRegridderExt.jl")
+
+end

--- a/ext/ClimaUtilitiesNCDatasetsExt.jl
+++ b/ext/ClimaUtilitiesNCDatasetsExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesNCDatasetsExt
+
+include("NCFileReaderExt.jl")
+
+end

--- a/src/Regridders.jl
+++ b/src/Regridders.jl
@@ -35,11 +35,19 @@ based on which regridder(s) are currently loaded.
 function default_regridder_type()
     # Use InterpolationsRegridder if available
     if !isnothing(
-        Base.get_extension(ClimaUtilities, :InterpolationsRegridderExt),
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreInterpolationsExt,
+        ),
     )
         regridder_type = :InterpolationsRegridder
         # If InterpolationsRegridder isn't available, and TempestRegridder is, use TempestRegridder
-    elseif !isnothing(Base.get_extension(ClimaUtilities, :TempestRegridderExt))
+    elseif !isnothing(
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreTempestRemapExt,
+        ),
+    )
         regridder_type = :TempestRegridder
     else
         error("No regridder available")

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -43,7 +43,10 @@ using NCDatasets
 
         # Test that we need to close all the variables to close the file
         open_ncfiles =
-            Base.get_extension(ClimaUtilities, :NCFileReaderExt).OPEN_NCFILES
+            Base.get_extension(
+                ClimaUtilities,
+                :ClimaUtilitiesNCDatasetsExt,
+            ).NCFileReaderExt.OPEN_NCFILES
 
         close(ncreader_sp)
         @test !isempty(open_ncfiles)
@@ -61,8 +64,8 @@ end
         read_dates_func =
             Base.get_extension(
                 ClimaUtilities,
-                :NCFileReaderExt,
-            ).read_available_dates
+                :ClimaUtilitiesNCDatasetsExt,
+            ).NCFileReaderExt.read_available_dates
 
         available_dates = read_dates_func(nc)
         @test isempty(available_dates)
@@ -78,7 +81,10 @@ end
 
         FileReaders.close_all_ncfiles()
         open_ncfiles =
-            Base.get_extension(ClimaUtilities, :NCFileReaderExt).OPEN_NCFILES
+            Base.get_extension(
+                ClimaUtilities,
+                :ClimaUtilitiesNCDatasetsExt,
+            ).NCFileReaderExt.OPEN_NCFILES
         @test isempty(open_ncfiles)
     end
 end


### PR DESCRIPTION
Extensions are defined to mirror the modules defined in src. However, this leads to circular dependencies, where some extensions trigger the loading of others. This is not properly handled by the precompiling logic in Julia as of Julia 1.9-1.11 (fixed in master, upcoming to Julia 1.12, or maybe it will be backported at some point).

Here, I change the way extensions are organized to match the packages that are needed to load them. In this, I still maintain the abstraction that each module in `src` has its implementation in `ext/XYZExt.jl`.

I also added the prefix `ClimaUtilities` to everything to make sure that it won't clash with anything.

Closes #68 
