### PR TITLE
Add support for boundary conditions in TimeVaryingInputs

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+v0.1.11
+------
+
+- Add support for boundary conditions in interpolation. PR
+  [#73](https://github.com/CliMA/ClimaUtilities.jl/pull/73)
+
 v0.1.10
 ------
 

--- a/docs/src/datahandling.md
+++ b/docs/src/datahandling.md
@@ -103,4 +103,5 @@ ClimaUtilities.DataHandling.previous_time
 ClimaUtilities.DataHandling.next_time
 ClimaUtilities.DataHandling.regridded_snapshot
 ClimaUtilities.DataHandling.regridded_snapshot!
+ClimaUtilities.DataHandling.dt
 ```

--- a/docs/src/inputs.md
+++ b/docs/src/inputs.md
@@ -75,6 +75,28 @@ albedo_tv = TimeVaryingInputs.TimeVaryingInput("cesem_albedo.nc", "alb", target_
 # model developers do not have to worry about anything :)
 ```
 
+`TimeVaryingInput`s can have multiple boundary conditions for extrapolation. By
+default, the `Throw` condition is used, meaning that interpolating onto a
+point that is outside the range of definition of the data is not allowed. Other
+boundary conditions are allowed. For instance, the `PeriodicCalendar` condition
+"repeats" the data over and over. With this boundary condition, if the data is
+defined over a period of time from `t0` to `t1` (e.g., 1 and 5), interpolating
+over `t > t1` (e.g., 7) is equivalent to interpolating to `t*` where `t*` is the
+modulus of `t` and the range (3 in this case). This can be used to repeat one
+year of data (suppose you have data defined on the 15th of every month for the a
+given year Y. With `PeriodicCalendar`, you evaluate the data for any year using
+data for Y). `PeriodicCalendar` requires the data to be uniformly spaced in
+time. To enable this boundary condition, pass
+`LinearInterpolation(PeriodicCalendar())` to the `TimeVaryingInput` (or
+`NearestNeighbor(PeriodicCalendar())`).
+
+> Note: this `PeriodicCalendar` is different from what you might be used to, where the
+> identification is `t1 = t0`. Here, we identify `t1 + dt = t0`. This is so that
+> we can use it to repeat calendar data.
+
+Another option is `Flat`: when interpolating outside of the range of
+definition, return the value of the closest boundary.
+
 ## `SpaceVaryingInputs`
 
 > This extension is loaded when loading `ClimaCore` is loaded. In addition to
@@ -124,9 +146,14 @@ albedo_from_file = SpaceVaryingInputs.SpaceVaryingInput("cesm_albedo.nc", "alb",
 ```@docs
 ClimaUtilities.SpaceVaryingInputs.SpaceVaryingInput
 ClimaUtilities.TimeVaryingInputs.AbstractInterpolationMethod
+ClimaUtilities.TimeVaryingInputs.AbstractInterpolationBoundaryMethod
 ClimaUtilities.TimeVaryingInputs.NearestNeighbor
 ClimaUtilities.TimeVaryingInputs.LinearInterpolation
+ClimaUtilities.TimeVaryingInputs.Throw
+ClimaUtilities.TimeVaryingInputs.PeriodicCalendar
+ClimaUtilities.TimeVaryingInputs.Flat
 ClimaUtilities.TimeVaryingInputs.evaulate!
+ClimaUtilities.TimeVaryingInputs.extrapolation_bc
 Base.in
 Base.close
 ```

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -11,6 +11,8 @@ import ClimaUtilities.Regridders
 import ClimaUtilities.FileReaders: AbstractFileReader, NCFileReader, read
 import ClimaUtilities.Regridders: AbstractRegridder, regrid
 
+import ClimaUtilities.Utils: isequispaced
+
 import ClimaUtilities.DataHandling
 
 """
@@ -224,6 +226,21 @@ function DataHandling.available_dates(data_handler::DataHandler)
 end
 
 """
+    dt(data_handler::DataHandler)
+
+Return the time interval between for the data in `data_handler`.
+
+This requires the data to be defined on a equispaced temporal mesh.
+"""
+function DataHandling.dt(data_handler::DataHandler)
+    isequispaced(DataHandling.available_times(data_handler)) ||
+        error("dt not defined for non equispaced data")
+    return DataHandling.available_times(data_handler)[begin + 1] -
+           DataHandling.available_times(data_handler)[begin]
+end
+
+
+"""
     time_to_date(data_handler::DataHandler, time::AbstractFloat)
 
 Convert the given time to a calendar date.
@@ -244,6 +261,8 @@ end
 
 Return the time in seconds of the snapshot before the given `time`.
 If `time` is one of the snapshots, return itself.
+
+If `time` is not in the `data_handler`, return an error.
 """
 function DataHandling.previous_time(
     data_handler::DataHandler,
@@ -263,6 +282,7 @@ function DataHandling.previous_time(
     else
         index = searchsortedfirst(data_handler.available_dates, date) - 1
     end
+    index < 1 && error("Date $date is before available dates")
     return data_handler.available_times[index]
 end
 
@@ -272,6 +292,8 @@ end
 
 Return the time in seconds of the snapshot after the given `time`.
 If `time` is one of the snapshots, return the next time.
+
+If `time` is not in the `data_handler`, return an error.
 """
 function DataHandling.next_time(data_handler::DataHandler, time::AbstractFloat)
     date = time_to_date(data_handler, time)
@@ -285,6 +307,8 @@ function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
     else
         index = searchsortedfirst(data_handler.available_dates, date)
     end
+    index > length(data_handler.available_dates) &&
+        error("Date $date is after available dates")
     return data_handler.available_times[index]
 end
 

--- a/src/DataHandling.jl
+++ b/src/DataHandling.jl
@@ -55,4 +55,6 @@ function regridded_snapshot end
 
 function regridded_snapshot! end
 
+function dt end
+
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -32,6 +32,7 @@ returns the endpoint value closest.
 function linear_interpolation(indep_vars, dep_vars, indep_value)
     N = length(indep_vars)
     id = searchsortedfirst(indep_vars, indep_value)
+    indep_value in indep_vars && return dep_vars[id]
     if id == 1
         dep_vars[begin]
     elseif id == N + 1
@@ -43,4 +44,134 @@ function linear_interpolation(indep_vars, dep_vars, indep_value)
         y0 + (y1 - y0) / (x1 - x0) * (indep_value - x0)
     end
 end
+
+"""
+    isequispaced(v; tol::Real = sqrt(eps(eltype(v)))
+
+Check if the vector `v` has uniform spacing between its elements within a given tolerance
+`tol`.
+
+# Arguments
+- `v::AbstractVector{<:Number}`: A vector of numerical values.
+- `tol::Real`: A tolerance value to account for floating-point precision errors (default is
+  `sqrt(eps(eltype(v)))`).
+
+# Returns
+
+- `Bool`: Returns `true` if the vector is equispaced within the given tolerance, `false`
+  otherwise.
+
+# Example
+
+```jldoctest
+julia> v1 = [1, 2, 3, 4, 5];
+julia> isequispaced(v1)
+true
+
+julia> v2 = [1, 2, 4, 8, 16];
+julia> isequispaced(v2)
+false
+
+julia> v3 = [1.0, 2.0, 3.0, 4.0, 5.0];
+julia> isequispaced(v3)
+true
+
+julia> v4 = [1.0, 2.0, 3.1, 4.0, 5.0];
+julia> isequispaced(v4)
+false
+```
+"""
+function isequispaced(
+    v;
+    tol = eltype(v) <: AbstractFloat ? sqrt(eps(eltype(v))) : eps(),
+)
+    length(v) < 2 && return true
+    diffs = diff(v)
+    return all(abs(d - diffs[begin]) < tol for d in diffs)
+end
+
+"""
+    wrap_time(time, t_init, t_end; extend_past_t_end = false, dt = nothing)
+
+Return `time` assuming periodicity so that `t_init <= time < t_end`.
+
+Two modes are available:
+
+When `extend_past_t_end` is true, wrap time at `t_end + dt` instead of `t_end`. This is
+often used when time is a calendar date. For example, if `t_init = 15 Jan` and `t_end = 15
+Dec`, and `dt = 1 Month`, one typically wants to identify `t_init = t_end + 1 Month`.
+
+To better understand the difference, consider the examples below.
+
+> Note: pay attention to the floating point representation! Sometimes it will lead to
+  unexpected results.
+
+Examples
+========
+
+With `extend_past_t_end = false`:
+
+```jldoctest
+julia> t_init = 0.1; t_end = 1.0;
+julia> wrap_time(0.1, t_init, t_end)
+0.1
+
+julia> wrap_time(0.5, t_init, t_end)
+0.5
+
+julia> wrap_time(0.8, t_init, t_end)
+0.8
+
+julia> wrap_time(1.0, t_init, t_end)
+0.1
+
+julia> wrap_time(1.6, t_init, t_end)
+0.7
+
+julia> wrap_time(2.2, t_init, t_end)
+0.4
+
+# Floating points, 1.9 should be identified with 0.1, but
+julia> wrap_time(1.9, t_init, t_end)
+0.9999999999999998
+```
+
+With `extend_past_t_end = true`:
+
+```jldoctest
+julia> t_init = 0.1; t_end = 1.0; extend_past_t_end = true; dt = 0.1
+julia> wrap_time(0.1, t_init, t_end; extend_past_t_end, dt)
+0.1
+
+julia> wrap_time(0.5, t_init, t_end; extend_past_t_end, dt)
+0.5
+
+julia> wrap_time(0.8, t_init, t_end; extend_past_t_end, dt)
+0.8
+
+julia> wrap_time(1.0, t_init, t_end; extend_past_t_end, dt)
+1.0
+
+julia> wrap_time(1.1, t_init, t_end; extend_past_t_end, dt)
+0.1
+
+julia> wrap_time(1.6, t_init, t_end; extend_past_t_end, dt)
+0.6
+
+julia> wrap_time(2.2, t_init, t_end; extend_past_t_end, dt)
+0.2000000000000001
+```
+"""
+function wrap_time(time, t_init, t_end; extend_past_t_end = false, dt = nothing)
+    extend_past_t_end &&
+        isnothing(dt) &&
+        error("dt required with extend_past_t_end = true")
+    if extend_past_t_end
+        t_end = t_end + dt
+        return wrap_time(time, t_init, t_end; extend_past_t_end = false)
+    end
+    period = t_end - t_init
+    return t_init + mod(time - t_init, period)
+end
+
 end

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -135,7 +135,15 @@ end
                 available_times = DataHandling.available_times(data_handler)
                 available_dates = DataHandling.available_dates(data_handler)
 
+                @test DataHandling.dt(data_handler) ==
+                      available_times[2] - available_times[1]
+
                 # Previous time with time
+                @test_throws ErrorException DataHandling.previous_time(
+                    data_handler,
+                    available_times[1] - 1,
+                )
+
                 @test DataHandling.previous_time(
                     data_handler,
                     available_times[10] + 1,
@@ -144,6 +152,17 @@ end
                     data_handler,
                     available_times[1] + 1,
                 ) == available_times[1]
+
+                # Previous time with time, boundaries (return the node)
+                @test DataHandling.previous_time(
+                    data_handler,
+                    available_times[1],
+                ) == available_times[1]
+                @test DataHandling.previous_time(
+                    data_handler,
+                    available_times[end],
+                ) == available_times[end]
+
                 # Previous time with date
                 @test DataHandling.previous_time(
                     data_handler,
@@ -169,6 +188,11 @@ end
                 ) == available_times[10]
 
                 # Next time with time
+                @test_throws ErrorException DataHandling.next_time(
+                    data_handler,
+                    available_times[end] + 1,
+                )
+
                 @test DataHandling.next_time(
                     data_handler,
                     available_times[10] + 1,

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -1,7 +1,3 @@
-#=
-    Unit tests for ClimaLand FileReaders module
-=#
-
 using Artifacts
 using Dates
 using Test

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,9 +1,18 @@
 using SafeTestsets
 using Pkg
 
-Pkg.Artifacts.ensure_all_artifacts_installed(
-    joinpath(@__DIR__, "Artifacts.toml"),
-)
+# Download test-only artifacts
+#
+# (Currently not natively supported by Julia)
+artifacts_toml = joinpath(@__DIR__, "Artifacts.toml")
+artifacts = Pkg.Artifacts.select_downloadable_artifacts(artifacts_toml)
+for name in keys(artifacts)
+    Pkg.Artifacts.ensure_artifact_installed(
+        name,
+        artifacts[name],
+        artifacts_toml,
+    )
+end
 
 # Performance and code quality tests
 @safetestset "Aqua tests" begin

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -1,6 +1,7 @@
 using Test
 
-import ClimaUtilities.Utils: searchsortednearest, linear_interpolation
+import ClimaUtilities.Utils:
+    searchsortednearest, linear_interpolation, isequispaced, wrap_time
 
 @testset "searchsortednearest" begin
     A = 10 * collect(range(1, 10))
@@ -22,4 +23,37 @@ end
     @test linear_interpolation([1.0, 2.0, 3.0], [2.0, 4.0, 6.0], 3.0) ≈ 6.0
     # Test with different starting value
     @test linear_interpolation([0.0, 1.0, 2.0], [1.0, 4.0, 9.0], 0.5) ≈ 2.5
+end
+
+@testset "isequispaced" begin
+    @test isequispaced([1, 2, 3, 4, 5])
+    @test !isequispaced([1, 2, 4, 8, 16])
+    @test isequispaced([1.0, 2.0, 3.0, 4.0, 5.0])
+    @test !isequispaced([1.0, 2.0, 3.1, 4.0, 5.0])
+end
+
+@testset "wrap_time" begin
+    t_init = 10
+    t_end = 20
+    dt = 1
+
+    @test wrap_time(15, t_init, t_end) == 15
+    @test wrap_time(25, t_init, t_end) == 15
+    @test wrap_time(5, t_init, t_end) == 15
+
+    # Wrapping when time equals t_init or t_end
+    @test wrap_time(10, t_init, t_end) == 10
+    @test wrap_time(20, t_init, t_end) == 10
+
+    # Wrapping with extend_past_t_end
+    @test wrap_time(25, t_init, t_end; extend_past_t_end = true, dt) == 14
+    @test wrap_time(35, t_init, t_end; extend_past_t_end = true, dt) == 13
+    @test wrap_time(5, t_init, t_end; extend_past_t_end = true, dt) == 16
+
+    @test_throws ErrorException wrap_time(
+        25,
+        t_init,
+        t_end;
+        extend_past_t_end = true,
+    )
 end


### PR DESCRIPTION
This commit implements boundary conditions for extrapolation of TimeVaryingInputs.

Boundary conditions are specified with subtypes of `AbstractInterpolationMethod` and passed to the `InterpolationMethod`.

Currently, three boundary conditions are implemented:

- `ThrowError`. This recovers the previous behavior and essentially means that extrapolation in time is not allowed
- `Clamp`. This clamps extrapolated values to the closest edge.
- `PeriodicCalendar`. More on this below.

`ThrowError` and `Clamp` are implemented at the level of the main `evaluate!`, while `PeriodicCalendar` requires more infrastructure.

`PeriodicCalendar` lays the groundwork for allowing a `TimeVaryingInput` to repeat itself in a way that is somewhat aware of the time duration.

Consider the example where we have data on the 15th of every month for the year 2024: 01/15/24, 02/15/24, ....., 12/15/24

`PeriodicCalendar` "repeats" this year as it the data we had was 12/15/23, 01/15/24, 02/15/24, ....., 12/15/24, 01/15/25, ...
where every year is identical to 2024.

This is not fully implemented yet, reason being that months have different number of days, which is an extra complication. Instead, this commit requires the data to be uniformly sampled. This is needed because we need to know what comes after t_end.

I will add support for dates next.