### PR TITLE
Make LRUCache an AbstractDict

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -17,7 +17,7 @@ import Base: Callable
 
 export LRUCache
 
-struct LRUCache{K, V}
+struct LRUCache{K, V} <: AbstractDict{K, V}
     """The cache itself, containing key-value pairs of information."""
     cache::Dict{K, V}
 


### PR DESCRIPTION
PR #79 adds most methods required for the LRUCache to behave like a dictionary. Now, we can just make it a subtype of `AbstractDict` so that it can be more integrated with the rest of julia's ecosystem.