### PR TITLE
Make artifacts test more MPI-robust

### DIFF
--- a/test/clima_artifacts.jl
+++ b/test/clima_artifacts.jl
@@ -27,7 +27,10 @@ let_filesystem_catch_up() = context isa ClimaComms.MPICommsContext && sleep(0.2)
 expected_path = artifact"socrates"
 
 # Remove the artifact, so that we test that we are downloading it
-Base.Filesystem.rm(expected_path, recursive = true)
+ClimaComms.iamroot(context) &&
+    Base.Filesystem.rm(expected_path, force = true, recursive = true)
+ClimaComms.barrier(context)
+let_filesystem_catch_up()
 @info "Removed artifact"
 
 @testset "Lazy artifact with context" begin


### PR DESCRIPTION
`Base.Filesystem.rm(expected_path, recursive = true)` can fail when run over multiple MPI processes because different ranks might have different view of the filesystem. A possible solution is to add `force = true` (so that ranks will not complain if the file does not exist). In addition to that, we can also explicitly ask that only root executes the rm command
