### PR TITLE
Add LinearPeriodFillingInterpolation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@ ClimaUtilities.jl Release Notes
 v0.1.12
 -------
 
+- Add support for interpolating while "period filling". PR
+  [#85](https://github.com/CliMA/ClimaUtilities.jl/pull/85)
 - Add support for boundary conditions in interpolation. PR
   [#84](https://github.com/CliMA/ClimaUtilities.jl/pull/84)
 - Increased allocations in regridding. `read!` method removed. PR

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.11"
+version = "0.1.12"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,6 +8,13 @@ import ClimaCore
 import NCDatasets
 import ClimaCoreTempestRemap
 
+DocMeta.setdocmeta!(
+    ClimaUtilities,
+    :DocTestSetup,
+    :(using Dates);
+    recursive = true,
+)
+
 pages = [
     "Overview" => "index.md",
     "ClimaArtifacts" => "climaartifacts.md",

--- a/docs/src/datastructures.md
+++ b/docs/src/datastructures.md
@@ -70,4 +70,5 @@ Base.pop!
 Base.delete!
 Base.getindex
 Base.setindex!
+Base.length
 ```

--- a/ext/TimeVaryingInputs0DExt.jl
+++ b/ext/TimeVaryingInputs0DExt.jl
@@ -10,7 +10,12 @@ import ClimaUtilities.Utils:
 import ClimaUtilities.TimeVaryingInputs:
     AbstractInterpolationMethod, AbstractTimeVaryingInput
 import ClimaUtilities.TimeVaryingInputs:
-    NearestNeighbor, LinearInterpolation, Throw, Flat, PeriodicCalendar
+    NearestNeighbor,
+    LinearInterpolation,
+    LinearPeriodFillingInterpolation,
+    Throw,
+    Flat,
+    PeriodicCalendar
 import ClimaUtilities.TimeVaryingInputs: extrapolation_bc
 
 import ClimaUtilities.TimeVaryingInputs
@@ -120,6 +125,12 @@ function TimeVaryingInputs.TimeVaryingInput(
     issorted(times) || error("Can only interpolate with sorted times")
     length(times) == length(vals) ||
         error("times and vals have different lengths")
+
+    if method isa LinearPeriodFillingInterpolation
+        error(
+            "LinearPeriodFillingInterpolation is not supported when the input data is 1D",
+        )
+    end
 
     if extrapolation_bc(method) isa PeriodicCalendar
         if extrapolation_bc(method) isa PeriodicCalendar{Nothing}

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -346,15 +346,21 @@ function TimeVaryingInputs.evaluate!(
         end
     end
 
-    t0, t1 =
-        previous_time(itp.data_handler, time), next_time(itp.data_handler, time)
-    coeff = (time - t0) / (t1 - t0)
+    # We have to consider the edge case where time is precisely the last available_time.
+    # This is relevant also because it can be triggered by LinearPeriodFilling
+    if time in DataHandling.available_times(itp.data_handler)
+        regridded_snapshot!(dest, itp.data_handler, time)
+    else
+        t0, t1 = previous_time(itp.data_handler, time),
+        next_time(itp.data_handler, time)
+        coeff = (time - t0) / (t1 - t0)
 
-    field_t0, field_t1 = itp.preallocated_regridded_fields
-    regridded_snapshot!(field_t0, itp.data_handler, t0)
-    regridded_snapshot!(field_t1, itp.data_handler, t1)
+        field_t0, field_t1 = itp.preallocated_regridded_fields
+        regridded_snapshot!(field_t0, itp.data_handler, t0)
+        regridded_snapshot!(field_t1, itp.data_handler, t1)
 
-    dest .= (1 - coeff) .* field_t0 .+ coeff .* field_t1
+        dest .= (1 - coeff) .* field_t0 .+ coeff .* field_t1
+    end
     return nothing
 end
 

--- a/ext/time_varying_inputs_linearperiodfilling.jl
+++ b/ext/time_varying_inputs_linearperiodfilling.jl
@@ -1,0 +1,375 @@
+# This file is included in TimeVaryingInputsExt.jl
+
+"""
+    _period_difference(date_left, date_right, period::Dates.DatePeriod)
+
+Return the difference in periods (in `Dates.Period`) from `date_right` to `date_left`.
+
+For example, if `date_left` is 18/08/1995, `date_right` 17/01/1997, and `period = Year(1)`,
+the difference is 2 years.
+
+This difference can also be used move a date in `period_right` to `period_left` (or viceversa).
+
+In the example above, 18/08/1995 + 2 years is in `period_right` (or 17/01/1997 - 2 years is
+in `period_left`).
+"""
+function _period_difference(date_left, date_right, period::Dates.DatePeriod)
+    return beginningofperiod(date_right, period) -
+           beginningofperiod(date_left, period)
+end
+
+"""
+    _extract_period(date, period::Dates.DatePeriod)
+
+Return the beginning of the period with duration specified by `period`.
+
+This function is here mostly for clarity (because extracting period clearer in intent than beginning
+of period).
+
+Example
+========
+
+# TODO This jldoctest would require loading the extension...
+
+```
+julia> _extract_period(Date(1993, 8, 18), Year(1))
+DateTime(1993, 1, 1)
+
+julia> _extract_period(Date(1993, 8, 18), Month(1))
+DateTime(1993, 8, 1)
+```
+"""
+function _extract_period(date, period::Dates.DatePeriod)
+    return beginningofperiod(date, period)
+end
+
+"""
+    _neighboring_periods(date, available_periods, period::Dates.DatePeriod)
+
+Return the two periods within `available_periods` that neighbor `date`.
+
+Example
+========
+
+# TODO This jldoctest would require loading the extension...
+
+```
+julia> available_periods = [DateTime(1985, 1, 1), DateTime(1995, 1, 1), DateTime(2005, 1, 1)];
+
+julia> _neighboring_periods([DateTime(1993, 8, 18)], available_periods, Year(1))
+(DateTime(1985, 1, 1), DateTime(1995, 1, 1))
+
+julia> _extract_period(Date(1993, 8, 18), Month(1))
+DateTime(1993, 8, 1)
+```
+"""
+function _neighboring_periods(date, available_periods, period::Dates.DatePeriod)
+    index_period_right =
+        findfirst(d -> d >= beginningofperiod(date, period), available_periods)
+    index_period_left = index_period_right - 1
+    return available_periods[index_period_left],
+    available_periods[index_period_right]
+end
+
+"""
+    _move_date_to_period(date, target_period, period::Dates.DatePeriod)
+
+Return a new date so that it is the equivalent date in the `target_period`
+
+Example
+========
+
+# TODO This jldoctest would require loading the extension...
+
+```
+julia> _move_date_to_period(DateTime(1987, 3, 7), DateTime(1985, 1, 1), Year(1))
+DateTime(1985, 3, 7)
+
+julia> _move_date_to_period(DateTime(1987, 3, 7), DateTime(1995, 1, 1), Year(1))
+DateTime(1995, 3, 7)
+
+```
+"""
+function _move_date_to_period(date, target_period, period::Dates.DatePeriod)
+    period_offset = _period_difference(date, target_period, period)
+    return date + period_offset
+end
+
+"""
+    _date_in_range(date, left, right)
+
+Check if `date` is between `left` and `right`.
+
+Example
+========
+
+# TODO This jldoctest would require loading the extension...
+
+```
+julia> _date_in_range(DateTime(1993, 10, 11), DateTime(1993, 1, 11), DateTime(1993, 12, 11))
+true
+
+julia> _date_in_range(DateTime(1993, 1, 1), DateTime(1993, 1, 11), DateTime(1993, 12, 11))
+false
+```
+"""
+function _date_in_range(date, left, right)
+    return left <= date <= right
+end
+
+"""
+    _interpolable_range(dates_period_left, dates_period_right, period)
+
+Find the two dates that bound the interpolable region.
+
+The dates are returned defined in `period_left`
+
+The interpolable region is defined as the dates when interpolation can be immediately
+performed because corresponding dates in both periods are available.
+
+Have a look at the examples below for more information.
+
+Example
+========
+
+# TODO This jldoctest would require loading the extension...
+
+```
+julia> dates_period_left = [DateTime(1985, 1, 15), DateTime(1985, 2, 17), DateTime(1985, 12, 11)];
+
+julia> dates_period_right = [DateTime(1995, 1, 8), DateTime(199h5, 2, 18), DateTime(1995, 12, 18)];
+
+julia> period = Year(1);
+
+julia> _interpolable_range(dates_period_left, dates_period_right, period)
+[DateTime(1985, 1, 15), DateTime(1985, 12, 11)]
+
+julia> _interpolable_range([DateTime(1985, 1, 1), DateTime(1985, 12, 11)], dates_period_left, period)
+[DateTime(1985, 1, 8), DateTime(1985, 12, 11)]
+
+julia> _interpolable_range(dates_period_left, [DateTime(1995, 1, 3), DateTime(1985, 12, 21)], period)
+[DateTime(1985, 1, 3), DateTime(1985, 12, 21)]
+```
+"""
+function _interpolable_range(
+    dates_period_left,
+    dates_period_right,
+    period::Dates.DatePeriod,
+)
+    if length(unique(beginningofperiod.(dates_period_left, period))) != 1
+        error("dates in dates_period_left belongs to different periods")
+    end
+    if length(unique(beginningofperiod.(dates_period_right, period))) != 1
+        error("dates in dates_period_right belongs to different periods")
+    end
+
+    # First, we move all the dates to period_left
+    period_offset = _period_difference(
+        first(dates_period_left),
+        first(dates_period_right),
+        period,
+    )
+    dates_period_right_moved_to_left = dates_period_right .- period_offset
+
+    # Now, to identify the interpolable range, we go through all the dates and find
+    # the first that is larger than both the smallest (largest) entries in
+    # dates_period_left and dates_period_right_moved_to_left
+    #
+    # For example, for
+    # dates_period_left = [Date(1985, 1, 15), Date(1985, 2, 17), Date(1985, 12, 11)]
+    # dates_period_right = [Date(1995, 1, 8), Date(1995, 2, 18), Date(1995, 12, 18)]
+    #
+    # largest_first_date would be Date(1985, 1, 15) and smallest_last_date Date(1985, 12, 11).
+    largest_first_date = maximum([
+        minimum(dates_period_left),
+        minimum(dates_period_right_moved_to_left),
+    ])
+    smallest_last_date = minimum([
+        maximum(dates_period_left),
+        maximum(dates_period_right_moved_to_left),
+    ])
+
+    return largest_first_date, smallest_last_date
+end
+
+function TimeVaryingInputs.evaluate!(
+    dest,
+    itp::InterpolatingTimeVaryingInput23D,
+    time,
+    method::LinearPeriodFillingInterpolation,
+    args...;
+    kwargs...,
+)
+    # E.g., Year(1)
+    period = method.period
+
+    # E.g., [Date(1985, 1, 15), Date(1985, 2, 17), Date(1995, 1, 8), Date(1995, 2, 18),
+    # Date(2015, 1, 10)]
+    available_dates = DataHandling.available_dates(itp.data_handler)
+
+    # E.g., [Date(1985, 1, 1), Date(1995, 1, 1), Date(2005, 1, 1)]
+    available_periods = unique_periods(available_dates, period)
+
+    # E.g., Date(1987, 2, 1)
+    target_date = DataHandling.time_to_date(itp.data_handler, time)
+
+    # If the target date falls within an available period, we just interpolate it with
+    # LinearInterpolation()
+    if _extract_period(target_date, period) in available_periods
+        # Here we are just interpolating within some available data, so it is easy
+        TimeVaryingInputs.evaluate!(dest, itp, time, LinearInterpolation())
+        return nothing
+    end
+
+    # We can assume that time is defined in the range of available_times because we handle
+    # extrapolation boundary conditions elsewhere. For this reason, we will always have a
+    # left and right periods
+
+    # We are not in one of the available_periods, we have two cases: either we are in the
+    # interpolable region, or not. The interpolable region is a region where we can directly
+    # perform linear interpolation in both the left and right periods, and then interpolate
+    # the resulting two values.
+    #
+    # When we are not in the interpolable region, we have to reduce to that case. So, we
+    # have to identify two dates in the interpolable region that bound the desired date and
+    # interpolate across them.
+
+    # itp.preallocated_regridded_fields[1:2] is used internally by functions called by this
+    # function, so we should not used them here. Also, we will use dest as a working area to
+    # avoid extra allocations
+    tmp_field1, tmp_field2 = itp.preallocated_regridded_fields[(end - 1):end]
+
+    # E.g, Date(1985, 1, 1), Date(1995, 1, 1)
+    period_left, period_right =
+        _neighboring_periods(target_date, available_periods, period)
+
+    # E.g., Date(1985, 1, 15), Date(1985, 2, 17)
+    dates_period_left = filter(
+        d -> period_left <= d <= endofperiod(period_left, period),
+        available_dates,
+    )
+
+    # E.g., Date(1995, 1, 8), Date(1995, 2, 18)
+    dates_period_right = filter(
+        d -> period_right <= d <= endofperiod(period_right, period),
+        available_dates,
+    )
+
+    # Move the target date to the left period, where we can compare it with the interpolable
+    # range
+    # E.g., Date(1985, 2, 1)
+    target_date_in_left_period =
+        _move_date_to_period(target_date, period_left, period)
+
+    # E.g., [Date(1985, 1, 8), Date(1985, 2, 17)]
+    min_interpolable_range, max_interpolable_range =
+        _interpolable_range(dates_period_left, dates_period_right, period)
+
+    in_interpolable_region = _date_in_range(
+        target_date_in_left_period,
+        min_interpolable_range,
+        max_interpolable_range,
+    )
+
+    if in_interpolable_region
+        date_pre = _move_date_to_period(target_date, period_left, period)
+        date_post = _move_date_to_period(target_date, period_right, period)
+        time_pre = date_to_time(itp.data_handler, date_pre)
+        time_post = date_to_time(itp.data_handler, date_post)
+
+        # Linear interpolation: y = y0 * (1 - coeff) + coeff * y1
+        #
+        # coeff here is the period weight, for example, if we are interpolating in 1987
+        # from 1985 and 1985, it would be 2/10.
+
+        # E.g., 730 days
+        offset_periods_left =
+            beginningofperiod(target_date, period) - period_left
+        period_offset = period_right - period_left
+        coeff = offset_periods_left / period_offset
+
+        TimeVaryingInputs.evaluate!(dest, itp, time_pre, LinearInterpolation())
+        dest .*= (1 - coeff)
+        TimeVaryingInputs.evaluate!(
+            tmp_field1,
+            itp,
+            time_post,
+            LinearInterpolation(),
+        )
+        tmp_field1 .*= coeff
+        dest .+= tmp_field1
+        return nothing
+    else
+        # In this branch, we are not in the interpolable region. This can happen because the
+        # target_date is earlier than the left boundary or later than the right boundary of
+        # the interpolable region in one/both period_left and period_right.
+        #
+        # When that happens, we change the interpolation dates to be the boundaries of the
+        # interpolable region moved to the relevant period
+        #
+        # For example, for Date(1987, 1, 1), we would interpolate it with
+        # Date(1986, 2, 17) and Date(1987, 1, 15)
+        #
+        target_date_in_left_period =
+            _move_date_to_period(target_date, period_left, period)
+        target_date_in_right_period =
+            _move_date_to_period(target_date, period_right, period)
+
+        target_period = _extract_period(target_date, period)
+
+        if target_date_in_left_period >= maximum(dates_period_left) ||
+           target_date_in_right_period >= maximum(dates_period_right)
+            # First case, the date is later than the interpolable region
+            #
+            # E.g., Date(1987, 12, 31), in this case we interpolate with
+            # Date(1987, 2, 17) and Date(1988, 1, 15)
+            #
+            # For date_pre, we take the max of the interpolable range and bring it to the
+            # current period. For date_post, we take the min, and take it to the next period
+            date_pre = _move_date_to_period(
+                max_interpolable_range,
+                target_period,
+                period,
+            )
+            date_post = _move_date_to_period(
+                min_interpolable_range,
+                target_period + period,
+                period,
+            )
+        elseif minimum(dates_period_left) >= target_date_in_left_period ||
+               minimum(dates_period_right) >= target_date_in_right_period
+            # Second case, the date is  than the interpolable region
+            #
+            # E.g., Date(1987, 1, 1), in this case we interpolate with
+            # Date(1986, 2, 17) and Date(1987, 1, 15)
+            #
+            # For date_pre, we take the max of the interpolable range and bring it to the
+            # previous period. For date_post, we take the min, and take it to the current period
+            date_pre = _move_date_to_period(
+                max_interpolable_range,
+                target_period + period,
+                period,
+            )
+            date_post = _move_date_to_period(
+                min_interpolable_range,
+                target_period,
+                period,
+            )
+        else
+            error("We should not be here!")
+        end
+
+        time_pre = date_to_time(itp.data_handler, date_pre)
+        time_post = date_to_time(itp.data_handler, date_post)
+
+        # y = y0 * (1 - coeff) + coff * y1
+        TimeVaryingInputs.evaluate!(dest, itp, time_pre, method)
+        coeff = (time - time_pre) / (time_post - time_pre)
+        dest .*= (1 - coeff)
+        TimeVaryingInputs.evaluate!(tmp_field2, itp, time_post, method)
+        tmp_field2 .*= coeff
+        dest .+= tmp_field2
+        return nothing
+    end
+    return nothing
+end

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -43,7 +43,7 @@ end
 """
     Base.setindex!(cache::LRUCache{K, V}, value::V, key::K)
 
-Store the mapping from `key` to `value` in `cache`.
+Store the mapping from `key` to `value` in `cache`. Then, return `cache`.
 """
 function Base.setindex!(cache::LRUCache{K, V}, value::V, key::K) where {K, V}
     _update_priority!(cache, key)
@@ -93,6 +93,40 @@ function Base.get!(
     _update_priority!(cache, key)
     _enforce_size!(cache)
     return get!(default, cache.cache, key)
+end
+
+"""
+    Base.length(cache::LRUCache{K, V})
+
+Return the number of elements in `cache`.
+"""
+function Base.length(cache::LRUCache{K, V}) where {K, V}
+    return length(cache.cache)
+end
+
+"""
+    ==(cache1::LRUCache{K1, V2}, cache2::LRUCache{K2, V2})
+
+Return whether the two caches are identical in content and priority.
+"""
+function Base.:(==)(
+    cache1::LRUCache{K1, V1},
+    cache2::LRUCache{K2, V2},
+) where {K1, V1, K2, V2}
+    return cache1.max_size == cache2.max_size &&
+           cache1.cache == cache2.cache &&
+           cache1.priority == cache2.priority
+end
+
+"""
+    iterate(cache::LRUCache{K, V})
+
+Advance the iterator to obtain the next element. If no elements remain, nothing
+should be returned. Otherwise, a 2-tuple of the next element and the new
+iteration state should be returned.
+"""
+function Base.iterate(cache::LRUCache{K, V}) where {K, V}
+    return iterate(cache.cache)
 end
 
 """
@@ -155,8 +189,7 @@ end
 """
     Base.empty(cache::LRUCache{K, V}, key_type::DataType=K, value_type::DataType=V)
 
-
-Create an empty `LRUCache` with keys of type `key_type` and values of type `value_type`. 
+Create an empty `LRUCache` with keys of type `key_type` and values of type `value_type`.
 
 The second and third arguments are optional and default to the input's `keytype` and `valuetype`. 
 If only one of the two type is specified, it is assumed to be the `value_type`, and `key_type` is 

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -331,4 +331,55 @@ function period_to_seconds_float(period::Period)
     return period / Second(1)
 end
 
+"""
+    unique_periods(dates, period::DatePeriod)
+
+Extracts all the unique periods available in the input list of `dates` for a given `period`.
+
+A period is always defined from its starting day.
+
+# Examples
+
+```jldoctest
+julia> import ClimaUtilities.Utils: unique_periods;
+
+julia> dates = [DateTime(2022, 1, 1), DateTime(2022, 5, 15), DateTime(2023, 1, 1), DateTime(2023, 5, 5), DateTime(2024, 10, 10)];
+
+julia> unique_periods(dates, Year(1))
+3-element Vector{DateTime}:
+ 2022-01-01T00:00:00
+ 2023-01-01T00:00:00
+ 2024-01-01T00:00:00
+
+julia> unique_periods(dates, Month(1))
+5-element Vector{DateTime}:
+ 2022-01-01T00:00:00
+ 2022-05-01T00:00:00
+ 2023-01-01T00:00:00
+ 2023-05-01T00:00:00
+ 2024-10-01T00:00:00
+
+julia> unique_periods(dates, Week(1))
+5-element Vector{DateTime}:
+ 2021-12-27T00:00:00
+ 2022-05-09T00:00:00
+ 2022-12-26T00:00:00
+ 2023-05-01T00:00:00
+ 2024-10-07T00:00:00
+
+julia> unique_periods(dates, Day(1))
+5-element Vector{DateTime}:
+ 2022-01-01T00:00:00
+ 2022-05-15T00:00:00
+ 2023-01-01T00:00:00
+ 2023-05-05T00:00:00
+ 2024-10-10T00:00:00
+```
+"""
+function unique_periods(dates, period::DatePeriod)
+    period.value == 1 ||
+        error("Only simple periods (e.g., `Year(1)`) are supported")
+    return map(d -> beginningofperiod(d, period), dates) |> unique |> sort
+end
+
 end

--- a/test/data_structures.jl
+++ b/test/data_structures.jl
@@ -46,6 +46,30 @@ end
     @test_throws KeyError cache["c"]
 end
 
+@testset "length for LRUCache" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    @test length(cache) == 0
+
+    cache["a"] = 1
+    @test length(cache) == 1
+end
+
+@testset "== for LRUCache" begin
+    cache1 = DataStructures.LRUCache{String, Int}(max_size = 3)
+    cache2 = DataStructures.LRUCache{String, Int}(max_size = 4)
+
+    @test cache1 != cache2
+
+    cache3 = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    @test cache1 == cache3
+
+    cache1["a"] = 1
+
+    @test cache1 != cache3
+end
+
 @testset "get! with default value" begin
     cache = DataStructures.LRUCache{String, Int}(max_size = 3)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -60,6 +60,10 @@ end
     include("time_varying_inputs23.jl")
 end
 
+@safetestset "TimeVaryingInputs tests LinearPeriodFilling" begin
+    include("time_varying_inputs_linearperiodfilling.jl")
+end
+
 @safetestset "ClimaArtifacts tests" begin
     include("clima_artifacts.jl")
 end

--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -67,10 +67,30 @@ end
         ),
     )
 
+    # Test with LinearPeriodFillingInterpolation with a given period
+    # This is not allowed for 1D data because we don't have dates
+    @test_throws ErrorException TimeVaryingInputs.TimeVaryingInput(
+        sort(xs),
+        ys,
+        method = TimeVaryingInputs.LinearPeriodFillingInterpolation(),
+    )
+
     # Test PeriodicCalendar with non simple duration
     @test_throws ErrorException TimeVaryingInputs.PeriodicCalendar(
         Month(2),
         Date(2024),
+    )
+
+    # Test LinearPeriodFillingInterpolation with non simple duration
+    @test_throws ErrorException TimeVaryingInputs.LinearPeriodFillingInterpolation(
+        Month(2),
+        TimeVaryingInputs.Throw(),
+    )
+
+    # Test LinearPeriodFillingInterpolation with PeriodicCalendar (they are incompatible)
+    @test_throws ErrorException TimeVaryingInputs.LinearPeriodFillingInterpolation(
+        Year(1),
+        TimeVaryingInputs.PeriodicCalendar(),
     )
 
     for FT in (Float32, Float64)

--- a/test/time_varying_inputs_linearperiodfilling.jl
+++ b/test/time_varying_inputs_linearperiodfilling.jl
@@ -1,0 +1,187 @@
+using Test
+import Dates: DateTime, Day, Date, Year
+
+import ClimaUtilities
+import ClimaUtilities.Utils: period_to_seconds_float, linear_interpolation
+import ClimaUtilities: DataHandling
+import ClimaUtilities: TimeVaryingInputs
+import ClimaUtilities.TimeVaryingInputs: LinearPeriodFillingInterpolation
+
+import ClimaComms
+@static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
+
+import ClimaCore
+import Interpolations
+import NCDatasets
+
+const context = ClimaComms.context()
+ClimaComms.init(context)
+
+include("TestTools.jl")
+
+@testset "InterpolatingTimeVaryingInput23D with LinearPeriodFillingInterpolation" begin
+
+    # First, test the helper functions
+    _interpolable_range =
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreNCDatasetsExt,
+        ).TimeVaryingInputsExt._interpolable_range
+    _move_date_to_period =
+        Base.get_extension(
+            ClimaUtilities,
+            :ClimaUtilitiesClimaCoreNCDatasetsExt,
+        ).TimeVaryingInputsExt._move_date_to_period
+
+    dates_period_left =
+        [DateTime(1985, 1, 15), DateTime(1985, 2, 17), DateTime(1985, 12, 11)]
+    dates_period_right =
+        [DateTime(1995, 1, 8), DateTime(1995, 2, 18), DateTime(1995, 12, 18)]
+    period = Year(1)
+
+    @test _interpolable_range(dates_period_left, dates_period_right, period) ==
+          (DateTime(1985, 1, 15), DateTime(1985, 12, 11))
+    @test _interpolable_range(
+        [DateTime(1985, 1, 1), DateTime(1985, 12, 11)],
+        dates_period_right,
+        period,
+    ) == (DateTime(1985, 1, 8), DateTime(1985, 12, 11))
+    @test _interpolable_range(
+        dates_period_left,
+        [DateTime(1995, 1, 3), DateTime(1995, 12, 21)],
+        period,
+    ) == (DateTime(1985, 1, 15), DateTime(1985, 12, 11))
+
+    @test_throws ErrorException _interpolable_range(
+        [DateTime(1985, 1, 3), DateTime(1995, 12, 21)],
+        dates_period_right,
+        period,
+    )
+    @test_throws ErrorException _interpolable_range(
+        dates_period_left,
+        [DateTime(1985, 1, 3), DateTime(1995, 12, 21)],
+        period,
+    )
+
+    @test _move_date_to_period(
+        DateTime(1987, 3, 7),
+        DateTime(1985, 1, 1),
+        Year(1),
+    ) == DateTime(1985, 3, 7)
+    @test _move_date_to_period(
+        DateTime(1987, 3, 7),
+        DateTime(1995, 1, 1),
+        Year(1),
+    ) == DateTime(1995, 3, 7)
+
+    # First, we create a test NetCDF files
+    mktempdir() do tmpdir
+        data_path = joinpath(tmpdir, "somedata.nc")
+
+        lon_array = [-120.0, 0.0, 120]
+        lat_array = [-60.0, 0.0, 60]
+
+        # The dates are chosen so that we cover an non trivial overlap between the periods
+        # of the years 1985 and 1995.
+        dates = [
+            DateTime(1985, 1, 10),
+            DateTime(1985, 12, 13),
+            DateTime(1995, 1, 6),
+            DateTime(1995, 12, 11),
+        ]
+        reference_date = DateTime(1985, 1, 1)
+        t_start = 0.0
+
+        times = map(
+            d -> period_to_seconds_float(d - reference_date) - t_start,
+            dates,
+        )
+
+        ones_array = ones(Float64, (3, 3))
+
+        # data is a Matrix (3, 3, length(times)), each time slice has values of times
+        #
+        # The input data is linear so linear interpolation will be perfect
+        data = stack(map(t -> ones_array * t, times))
+
+        NCDatasets.NCDataset(data_path, "c") do nc
+            NCDatasets.defDim(nc, "lon", length(lon_array))
+            NCDatasets.defDim(nc, "lat", length(lat_array))
+            NCDatasets.defDim(nc, "time", length(times))
+            NCDatasets.defVar(nc, "lon", lon_array, ("lon",))
+            NCDatasets.defVar(nc, "lat", lon_array, ("lat",))
+            NCDatasets.defVar(nc, "time", dates, ("time",))
+            NCDatasets.defVar(nc, "data", data, ("lon", "lat", "time"))
+        end
+
+        regridder_type = :InterpolationsRegridder
+        FT = Float64
+        target_space = make_spherical_space(FT; context).horizontal
+        dest = ClimaCore.Fields.zeros(target_space)
+        one_field = ClimaCore.Fields.ones(target_space)
+
+        data_handler = DataHandling.DataHandler(
+            data_path,
+            "data",
+            target_space;
+            reference_date,
+            t_start,
+            regridder_type,
+        )
+
+        function totime(date)
+            return DataHandling.date_to_time(data_handler, date)
+        end
+
+        method = LinearPeriodFillingInterpolation()
+        input =
+            TimeVaryingInputs.TimeVaryingInput(data_handler; method, context)
+
+        function test_date(target_date)
+            target_time = totime(target_date)
+            expected = target_time .* one_field
+            TimeVaryingInputs.evaluate!(dest, input, target_time)
+            @test parent(dest) ≈ parent(expected)
+        end
+
+        # Outside of the domain of definition of the input data
+        @test_throws ErrorException TimeVaryingInputs.evaluate!(
+            dest,
+            input,
+            times[begin] - 1,
+        )
+
+        @test_throws ErrorException TimeVaryingInputs.evaluate!(
+            dest,
+            input,
+            times[end] + 1,
+        )
+
+        # Target time within the leftmost period
+        test_date(dates[begin] + Day(1))
+
+        # Target time within the leftmost period, but after the last date
+        test_date(DateTime(1985, 12, 14))
+
+        # Target time within the rightmost period
+        test_date(dates[end] - Day(1))
+
+        # Target time within the rightmost period, but before the first date
+        test_date(DateTime(1995, 1, 5))
+
+        # Target time falling into the interpolable region between two periods
+        test_date(DateTime(1987, 6, 18))
+
+        # Target time falling at the left of the interpolable region for both
+        test_date(DateTime(1987, 1, 1))
+
+        # Target time falling at the right of the interpolable region for both
+        test_date(DateTime(1987, 12, 31))
+
+        # Target time falling at the left of the interpolable region for one
+        test_date(DateTime(1987, 1, 8))
+
+        # Target time falling at the right of the interpolable region for one
+        test_date(DateTime(1987, 12, 12))
+    end
+end

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -10,7 +10,8 @@ import ClimaUtilities.Utils:
     beginningofperiod,
     endofperiod,
     bounding_dates,
-    period_to_seconds_float
+    period_to_seconds_float,
+    unique_periods
 
 @testset "searchsortednearest" begin
     A = 10 * collect(range(1, 10))
@@ -99,4 +100,44 @@ end
     @test period_to_seconds_float(Week(1)) == 604800.0
     @test period_to_seconds_float(Month(1)) == 2.629746e6
     @test period_to_seconds_float(Year(1)) == 3.1556952e7
+end
+
+@testset "unique_periods" begin
+    dates = [
+        DateTime(2022, 1, 1),
+        DateTime(2022, 5, 15),
+        DateTime(2023, 1, 1),
+        DateTime(2023, 5, 5),
+        DateTime(2024, 10, 10),
+    ]
+
+    # Test with non simple period
+    @test_throws ErrorException unique_periods(dates, Year(2))
+
+    @test unique_periods(dates, Year(1)) ==
+          [DateTime(2022, 1, 1), DateTime(2023, 1, 1), DateTime(2024, 1, 1)]
+
+    @test unique_periods(dates, Month(1)) == [
+        DateTime(2022, 1, 1),
+        DateTime(2022, 5, 1),
+        DateTime(2023, 1, 1),
+        DateTime(2023, 5, 1),
+        DateTime(2024, 10, 1),
+    ]
+
+    @test unique_periods(dates, Week(1)) == [
+        DateTime(2021, 12, 27),
+        DateTime(2022, 5, 9),
+        DateTime(2022, 12, 26),
+        DateTime(2023, 5, 1),
+        DateTime(2024, 10, 7),
+    ]
+
+    @test unique_periods(dates, Day(1)) == [
+        DateTime(2022, 1, 1),
+        DateTime(2022, 5, 15),
+        DateTime(2023, 1, 1),
+        DateTime(2023, 5, 5),
+        DateTime(2024, 10, 10),
+    ]
 end


### PR DESCRIPTION
This PR adds support for period-filling interpolation. From the docstring:

> Perform a period-filling linear interpolation between the two neighboring points.
> 
> This interpolation is period-filling because it ensures that there is no gap on input data
> larger than the given period.
> 
> This interpolation method is best explained with an example. Let us assume data is defined
> on 03/01/1985, 05/01/1985, 11/02/1985, ... 17/12/1985, 07/01/1995, 11/01/1995, 14/02/1995,
> ..., 19/12/1995. In this case, data is defined every 10 years (date format is DD/MM/YYYY).
> You can think of `LinearPeriodFillingInterpolation` as first filling the years in between by
> performing linear interpolation across years, then performs a second linear interpolation
> for the specific day (in actuality, the order of operations is reversed). In this example,
> suppose first we want to evaluate the input on 04/01/1985. Since we have data for 1985, we
> simply perform linear interpolation between 03/01/1985 and 05/01/1985. Suppose now, we want
> to evaluate on 08/01/1987. We do not have data for the year 1987, so, we perform three
> linear interpolations, first to evaluate the data on 08/01/1985 and 08/01/1995 (using the
> neighboring points), and then between the resulting two values.
> 
> `extrapolation_bc` specifies how to deal with out of boundary values. The default value is
> `Throw`, meaning that extrapolation is not allowed.
> 
> When is this interpolation method useful?
> ==========================================
> 
> This interpolation method is useful when certain variations are more important than others.
> For example, suppose you have hourly data defined once a month, on the 15th. A naive
> interpolation method would interpolate use data from 15 Jan at 23.00 and 15 Feb at 00.00 to
> interpolate on any day/hour of the days in between 15 Jan and 15 Feb. However, this would be
> remove the diurnal cycle. `LinearPeriodFillingInterpolation` solves this problem.
> 
> Implementation details
> ======================
> 
> How is `LinearPeriodFillingInterpolation` actually implemented?
> 
> First, let get a high level perspective. Let us continue with the example above.
> 
> There are two cases:
> 
> First, the target date falls within other dates that are boundary dates for the two
> neighboring years. An example is 08/01/1986 because both 08/01/1985 and 08/01/1995 have two
> neighboring dates (05/01/1985, 11/02/1985 and 07/01/1995, 11/01/1995). This is the easy
> case: we interpolate 05/01/1985 and 11/02/1985 to get 08/01/1985, and 07/01/1995 and
> 11/01/1995 to get 08/01/1995, and interpolate the two results to get 08/01/1986.
> 
> Second, the other cases, when the target date does not have two boundary dates defined in
> 1995. An example is 04/01/1986 because 07/01/1995 is the earliest date available on that
> year. We have to be careful with this interpolation because we do not want to mix December
> 1985 with January 1995. In this case, we perform another interpolation to obtain a date in
> December 1994 and reduce to the first case using this date as second half of the
> interpolation bracket. To find what date to interpolate to, we walk the available dates
> backwards in time at find the first date that we can interpolate because it falls into the
> first case. In this example, it is 11/02/1994 (which we can obtain because we have data for
> 11/12/1985 and we can interpolate data on 11/12/1995).

Closes #74 