### PR TITLE
Add Dict methods to LRUCache

### DIFF
--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -73,6 +73,145 @@ function Base.get!(
 end
 
 """
+    Base.get(cache::LRUCache{K, V}, key::K, default::V)
+
+Get the value associated with `key` in `cache`. If the key is not in the
+cache, return the `default`. If the `key` is in `cache`, update the key's priority.
+"""
+function Base.get(cache::LRUCache{K, V}, key::K, default::V) where {K, V}
+    if haskey(cache, key)
+        _update_priority!(cache, key)
+    end
+    return get(cache.cache, key, default)
+end
+
+"""
+    Base.get(default::Callable, cache::LRUCache{K, V}, key::K)
+
+Get the value associated with `key` in `cache`. If the key is not in the
+cache, return the `default`. In any case, update the key's priority.
+"""
+function Base.get(default::Callable, cache::LRUCache{K, V}, key::K) where {K, V}
+    if haskey(cache, key)
+        _update_priority!(cache, key)
+    end
+    return get(default, cache.cache, key)
+end
+
+"""
+    Base.haskey(cache::LRUCache{K, V}, key::K)
+Determine if the `key` has a mapping in the `cache` and return
+true if it is and false if it is not. 
+"""
+function Base.haskey(cache::LRUCache{K, V}, key::K) where {K, V}
+    return haskey(cache.cache, key)
+end
+
+"""
+    Base.copy(cache::LRUCache{K, V})
+
+Creates a shallow copy of `cache`.
+"""
+function Base.copy(cache::LRUCache{K, V}) where {K, V}
+    return LRUCache{K, V}(
+        copy(cache.cache),
+        cache.max_size,
+        copy(cache.priority),
+    )
+end
+
+"""
+    Base.deepcopy(cache::LRUCache{K, V})
+
+Creates a deep copy of `cache`.
+"""
+function Base.deepcopy(cache::LRUCache{K, V}) where {K, V}
+    return LRUCache{K, V}(
+        deepcopy(cache.cache),
+        cache.max_size,
+        deepcopy(cache.priority),
+    )
+end
+
+
+"""
+    Base.empty(cache::LRUCache{K, V}, [key_type::DataType=], [value_type::DataType=V])
+
+Creates an empty `LRUCache` with the same `max_size` as the input that has keys of type 
+`key_type` and values of type `value_type`. The second and third arguments are
+optional and default to the input's keytype and valuetype. If only one of the two type is specified,
+it is assumed to be the `value_type` and `key_type` is defaulted to the key type of the input.
+"""
+function Base.empty(
+    cache::LRUCache{K, V},
+    key_type::DataType = K,
+    value_type::DataType = V,
+) where {K, V}
+    return LRUCache{key_type, value_type}(max_size = cache.max_size)
+end
+
+function Base.empty(
+    cache::LRUCache{K, V},
+    value_type::DataType = V,
+) where {K, V}
+    return LRUCache{K, value_type}(max_size = cache.max_size)
+end
+
+"""
+    Base.empty!(cache::LRUCache{K, V})
+
+Removes all key/value mappings from the input, empties the priority list, and then returns the emptied input
+"""
+function Base.empty!(cache::LRUCache{K, V}) where {K, V}
+    empty!(cache.cache)
+    empty!(cache.priority)
+    return cache
+end
+
+"""
+    Base.pop!(cache::LRUCache{K, V}, key::K, [default::V])
+
+If a mapping for `key` exists in `cache`, delete the mapping and return the `value`. 
+If the `key` does not exist, then return `default` or throw an error if `default` is not specified
+"""
+function Base.pop!(cache::LRUCache{K, V}, key::K, default::V) where {K, V}
+    value = pop!(cache.cache, key, default)
+    filter!(k -> k != key, cache.priority)
+    return value
+end
+
+function Base.pop!(cache::LRUCache{K, V}, key::K) where {K, V}
+    value = pop!(cache.cache, key)
+    filter!(k -> k != key, cache.priority)
+    return value
+end
+
+"""
+    Base.delete!(cache::LRUCache{K, V}, key::K)
+
+Delete mapping for key, if it is cache, and return the LRUcache
+"""
+function Base.delete!(cache::LRUCache{K, V}, key::K) where {K, V}
+    value = delete!(cache.cache, key)
+    filter!(k -> k != key, cache.priority)
+    return value
+end
+
+"""
+   Base.merge(cache_1::LRUCache{K1, V1}, cache_2::LRUCache{K2, V2})
+
+Delete mapping for key, if it is cache, and return the LRUcache
+"""
+function Base.merge(
+    cache_1::LRUCache{K1, V1},
+    cache_2::LRUCache{K2, V2},
+) where {K1, V1, K2, V2}
+    throw(ErrorException("Merge not implemented for LRUCache"))
+    return
+end
+
+
+"""
     _update_priority!(cache, key)
 
 Update the priority of `key` in `cache` to reflect its most recent access.

--- a/test/data_structures.jl
+++ b/test/data_structures.jl
@@ -49,3 +49,201 @@ end
     @test cache.priority == ["c", "a", "d"]
     @test length(cache.priority) == length(keys(cache.cache)) == cache.max_size
 end
+
+@testset "get with default value" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test cache hits (key in dict)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+    @test get(cache, "a", 3) == 1
+    @test cache.priority == ["b", "a"]
+
+    # check cache miss (key not in dict)
+    @test get(cache, "c", 3) == 3
+    @test get(cache, "c", 2) == 2
+    @test cache.priority == ["b", "a"]
+end
+
+@testset "get with default callable" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test cache hits (key in dict)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+    @test get(() -> 3, cache, "a") == 1
+    @test cache.priority == ["b", "a"]
+
+    # # check cache miss (key not in dict)
+    @test get(() -> 3, cache, "c") == 3
+    @test get(() -> 2, cache, "c") == 2
+    @test cache.priority == ["b", "a"]
+end
+
+@testset "haskey LRU" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test haskey if key exists
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+    @test haskey(cache, "a") == true
+    # Check haskey doesnt mutate priority
+    @test cache.priority == ["a", "b"]
+    # Test if key does not exist
+    @test haskey(cache, "c") == false
+    @test cache.priority == ["a", "b"]
+
+    # Test if key added
+    get!(cache, "c", 3)
+    @test haskey(cache, "c") == true
+end
+
+@testset "copy LRU" begin
+    cache1 = DataStructures.LRUCache{String, Vector{Int64}}(max_size = 3)
+    get!(cache1, "a", [1])
+    get!(cache1, "b", [2])
+
+    # test copy for equivalence
+    cache2 = copy(cache1)
+    @test cache2.priority == cache1.priority
+    @test cache2.cache == cache1.cache
+    @test cache2.max_size == cache1.max_size
+
+    # check that copying object not just reference
+    get!(cache1, "c", [3])
+    @test cache2 != cache1
+
+    # check that it is shallow copying
+    cache2 = copy(cache1)
+    push!(get!(cache1, "a", [1]), 1)
+    @test cache2.cache == cache1.cache
+    @test cache2.priority != cache1.priority
+    @test cache2.priority == ["a", "b", "c"]
+end
+
+@testset "deepcopy" begin
+    cache1 =
+        DataStructures.LRUCache{String, Vector{Vector{Int64}}}(max_size = 3)
+    get!(cache1, "a", [[1]])
+    get!(cache1, "b", [[2]])
+
+    # test copy for equivalence
+    cache2 = deepcopy(cache1)
+    @test cache2.priority == cache1.priority
+    @test cache2.cache == cache1.cache
+    @test cache2.max_size == cache1.max_size
+
+    # test that copying object not just reference
+    get!(cache1, "c", [[3]])
+    @test cache2 != cache1
+
+    # test that it is deep copying
+    cache2 = deepcopy(cache1)
+    push!(getindex(get!(cache1, "a", [[1]]), 1), 1)
+    @test cache2.cache != cache1.cache
+    @test cache1.priority == ["b", "c", "a"]
+    @test cache2.priority == ["a", "b", "c"]
+end
+@testset "empty LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+
+    # test that it is returning a new empty LRUcache
+    empty_cache = empty(cache)
+    @test empty_cache != cache
+    # test that if not specified, key and value types are copied
+    @test empty_cache.cache == Dict{String, Int64}()
+    @test typeof(empty_cache.cache) == typeof(Dict{String, Int64}())
+    @test empty_cache.priority == []
+    @test empty_cache.max_size == cache.max_size
+
+    # test empty if a second arg is given
+    empty_cache = empty(cache, Char)
+    @test empty_cache.cache == Dict{String, Char}()
+    @test typeof(empty_cache.cache) == typeof(Dict{String, Char}())
+    @test typeof(empty_cache.priority) == Vector{String}
+
+    # test empty if two args are given
+    empty_cache = empty(cache, Int64, String)
+    @test empty_cache.cache == Dict{Int64, String}()
+    @test typeof(empty_cache.cache) == typeof(Dict{Int64, String}())
+    @test typeof(empty_cache.priority) == Vector{Int64}
+end
+
+@testset "empty! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+
+    # test that it is returning a new empty LRUcache
+    cache_reference_copy = cache
+    empty!(cache)
+    @test cache_reference_copy == cache
+    @test cache.cache == Dict{String, Int64}()
+    @test typeof(cache.cache) == typeof(Dict{String, Int64}())
+    @test cache.priority == []
+end
+
+@testset "empty! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+
+    # test that it is returning a new empty LRUcache
+    cache_reference_copy = cache
+    empty!(cache)
+    @test cache_reference_copy == cache
+    @test cache.cache == Dict{String, Int64}()
+    @test typeof(cache.cache) == typeof(Dict{String, Int64}())
+    @test cache.priority == []
+end
+
+@testset "pop! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+    get!(cache, "c", 3)
+
+    # test that it deletes and returns mapping for key if in cache
+    @test pop!(cache, "b") == 2
+    @test cache.cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+
+    # test that popping key that doesn't exist without specifying default
+    # throws error
+    @test_throws KeyError pop!(cache, "b")
+
+    # test that default returned if key not in cache
+    @test pop!(cache, "b", 5) == 5
+end
+
+@testset "delete! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache, "a", 1)
+    get!(cache, "b", 2)
+    get!(cache, "c", 3)
+
+    # test when key in cache, that it deletes and returns the cache
+    delete!(cache, "b")
+    @test cache.cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+
+    # test that deleting key that isnt in cache just returns the cache
+    delete!(cache, "b")
+    @test cache.cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+end
+
+
+@testset "merge LRU" begin
+    cache1 = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache1, "a", 1)
+    get!(cache1, "b", 2)
+    cache2 = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    get!(cache1, "a", 3)
+    get!(cache1, "c", 4)
+
+    # test merging two LRUcaches throws error
+    @test_throws ErrorException merge(cache1, cache2)
+end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Add expected Dict methods to LRUCache
Closes #79  -- this will automatically close issue 79 on PR merge
-->


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
-->


## Content
<!---  specific tasks that are currently complete 
Add haskey, copy, deepcopy, empty, empty!, get, pop!, delete!, and merge methods to LRUCache
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
