### PR TITLE
Add Dict methods to LRUCache

### DIFF
--- a/docs/src/datastructures.md
+++ b/docs/src/datastructures.md
@@ -60,4 +60,14 @@ end
 ```@docs
 ClimaUtilities.DataStructures.LRUCache
 Base.get!
+Base.get
+Base.haskey
+Base.copy
+Base.deepcopy
+Base.empty
+Base.empty!
+Base.pop!
+Base.delete!
+Base.getindex
+Base.setindex!
 ```

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -41,6 +41,29 @@ function LRUCache{K, V}(; max_size::Int = 128) where {K, V}
 end
 
 """
+    Base.setindex!(cache::LRUCache{K, V}, value::V, key::K)
+
+Store the mapping from `key` to `value` in `cache`.
+"""
+function Base.setindex!(cache::LRUCache{K, V}, value::V, key::K) where {K, V}
+    _update_priority!(cache, key)
+    _enforce_size!(cache)
+    cache.cache[key] = value
+    return cache
+end
+
+"""
+    Base.getindex(cache::LRUCache{K, V}, key::K)
+
+Return the mapping for `key` in `cache`.
+"""
+function Base.getindex(cache::LRUCache{K, V}, key::K) where {K, V}
+    value = cache.cache[key]
+    _update_priority!(cache, key)
+    return value
+end
+
+"""
     Base.get!(cache::LRUCache{K, V}, key::K, default::V) where {K, V}
 
 Get the value associated with `key` in `cache`. If the key is not in the
@@ -70,6 +93,141 @@ function Base.get!(
     _update_priority!(cache, key)
     _enforce_size!(cache)
     return get!(default, cache.cache, key)
+end
+
+"""
+    Base.get(cache::LRUCache{K, V}, key::K, default::V)
+
+Return the value associated with `key` in `cache`, or if `key` is not in `cache`,
+return `default`. 
+"""
+function Base.get(cache::LRUCache{K, V}, key::K, default::V) where {K, V}
+    haskey(cache, key) && return cache[key]
+    return default
+end
+
+"""
+    Base.get(default::Callable, cache::LRUCache{K, V}, key::K)
+
+Return the value associated with `key` in `cache`, or if the key is not in the
+cache, return `f()`.
+"""
+function Base.get(f::Callable, cache::LRUCache{K, V}, key::K) where {K, V}
+    haskey(cache, key) && return cache[key]
+    return f()
+end
+
+"""
+    Base.haskey(cache::LRUCache{K, V}, key::K)
+    
+Return whether `key` has a mapping in `cache`. 
+"""
+function Base.haskey(cache::LRUCache{K, V}, key::K) where {K, V}
+    return haskey(cache.cache, key)
+end
+
+"""
+    Base.copy(cache::LRUCache{K, V})
+
+Return a shallow copy of `cache`.
+"""
+function Base.copy(cache::LRUCache{K, V}) where {K, V}
+    return LRUCache{K, V}(
+        copy(cache.cache),
+        cache.max_size,
+        copy(cache.priority),
+    )
+end
+
+"""
+    Base.deepcopy(cache::LRUCache{K, V})
+
+Return a deep copy of `cache`.
+"""
+function Base.deepcopy(cache::LRUCache{K, V}) where {K, V}
+    return LRUCache{K, V}(
+        deepcopy(cache.cache),
+        cache.max_size,
+        deepcopy(cache.priority),
+    )
+end
+
+"""
+    Base.empty(cache::LRUCache{K, V}, key_type::DataType=K, value_type::DataType=V)
+
+
+Create an empty `LRUCache` with keys of type `key_type` and values of type `value_type`. 
+
+The second and third arguments are optional and default to the input's `keytype` and `valuetype`. 
+If only one of the two type is specified, it is assumed to be the `value_type`, and `key_type` is 
+assumed to the key type of `cache`.
+"""
+function Base.empty(
+    cache::LRUCache{K, V},
+    key_type::DataType,
+    value_type::DataType,
+) where {K, V}
+    return LRUCache{key_type, value_type}(max_size = cache.max_size)
+end
+
+function Base.empty(
+    cache::LRUCache{K, V},
+    value_type::DataType = V,
+) where {K, V}
+    return LRUCache{K, value_type}(max_size = cache.max_size)
+end
+
+"""
+    Base.empty!(cache::LRUCache{K, V})
+
+Remove all key/value mappings from the input and return the emptied input.
+"""
+function Base.empty!(cache::LRUCache{K, V}) where {K, V}
+    empty!(cache.cache)
+    empty!(cache.priority)
+    return cache
+end
+
+"""
+    Base.pop!(cache::LRUCache{K, V}, key::K, [default::V])
+
+Delete the mapping for `key` in `cache` and return the associated `value`, or 
+if the `key` does not exist, return `default` or throw an error if `default` is not specified
+"""
+function Base.pop!(cache::LRUCache{K, V}, key::K, default::V) where {K, V}
+    value = pop!(cache.cache, key, default)
+    filter!(k -> k != key, cache.priority)
+    return value
+end
+
+function Base.pop!(cache::LRUCache{K, V}, key::K) where {K, V}
+    value = pop!(cache.cache, key)
+    filter!(k -> k != key, cache.priority)
+    return value
+end
+
+"""
+    Base.delete!(cache::LRUCache{K, V}, key::K)
+
+Delete mapping for `key`, if it is in`cache`, and return `cache`
+"""
+function Base.delete!(cache::LRUCache{K, V}, key::K) where {K, V}
+    value = delete!(cache.cache, key)
+    filter!(k -> k != key, cache.priority)
+    return cache
+end
+
+"""
+   Base.merge(cache_1::LRUCache{K1, V1}, cache_2::LRUCache{K2, V2})
+
+Merge not implemented for LRUCache
+"""
+function Base.merge(
+    cache_1::LRUCache{K1, V1},
+    cache_2::LRUCache{K2, V2},
+) where {K1, V1, K2, V2}
+    error("Merge not implemented for LRUCache")
+    return nothing
 end
 
 """

--- a/test/data_structures.jl
+++ b/test/data_structures.jl
@@ -8,6 +8,44 @@ import ClimaUtilities.DataStructures
     @test cache.max_size == 10
 end
 
+@testset "setindex! for LRUCache" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test adding new values (cache misses)
+    @test setindex!(cache, 1, "a") == cache
+    @test cache.priority == ["a"]
+    cache["b"] = 2
+    @test cache.priority == ["a", "b"]
+
+    # Test updating existing key value
+    cache["a"] = 3
+    @test cache.cache == Dict{String, Int64}("a" => 3, "b" => 2)
+    @test cache.priority == ["b", "a"]
+
+    # Test enforcing size limit
+    cache["c"] = 4
+    cache["d"] = 5
+    @test cache.cache == Dict{String, Int64}("a" => 3, "c" => 4, "d" => 5)
+    @test cache.priority == ["a", "c", "d"]
+    @test length(cache.priority) == length(keys(cache.cache)) == cache.max_size
+end
+
+@testset "getindex for LRUCache" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test getting value for key that is in cache
+    cache["a"] = 1
+    @test getindex(cache, "a") == 1
+
+    # Add "b", then access "a" to ensure getindex updates priority
+    cache["b"] = 2
+    cache["a"]
+    @test cache.priority == ["b", "a"]
+
+    # Test behavior if key not in cache
+    @test_throws KeyError cache["c"]
+end
+
 @testset "get! with default value" begin
     cache = DataStructures.LRUCache{String, Int}(max_size = 3)
 
@@ -48,4 +86,182 @@ end
     get!(() -> 5, cache, "d")
     @test cache.priority == ["c", "a", "d"]
     @test length(cache.priority) == length(keys(cache.cache)) == cache.max_size
+end
+
+@testset "get with default value" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test cache hits (key in dict)
+    cache["a"] = 1
+    cache["b"] = 2
+    @test get(cache, "a", 3) == 1
+    @test cache.priority == ["b", "a"]
+
+    # Test cache miss (key not in dict)
+    @test get(cache, "c", 3) == 3
+    @test get(cache, "c", 2) == 2
+    @test cache.priority == ["b", "a"]
+end
+
+@testset "get with default callable" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test cache hits (key in dict)
+    cache["a"] = 1
+    cache["b"] = 2
+    @test get(() -> 3, cache, "a") == 1
+    @test cache.priority == ["b", "a"]
+
+    # Test cache miss (key not in dict)
+    @test get(() -> 3, cache, "c") == 3
+    @test get(() -> 2, cache, "c") == 2
+    @test cache.priority == ["b", "a"]
+end
+
+@testset "haskey LRU" begin
+    cache = DataStructures.LRUCache{String, Int}(max_size = 3)
+
+    # Test haskey if key exists
+    cache["a"] = 1
+    cache["b"] = 2
+    @test haskey(cache, "a")
+
+    # Test haskey doesnt mutate priority
+    @test cache.priority == ["a", "b"]
+
+    # Test if key does not exist
+    @test !haskey(cache, "c")
+    @test cache.priority == ["a", "b"]
+
+    # Test if key added
+    cache["c"] = 5
+    @test haskey(cache, "c")
+end
+
+@testset "copy LRU" begin
+    cache = DataStructures.LRUCache{String, Vector{Int64}}(max_size = 3)
+    cache["a"] = [1]
+    cache["b"] = [2]
+
+    # Test copy for equivalence
+    @test copy(cache).priority == cache.priority
+    @test copy(cache).cache == cache.cache
+    @test copy(cache).max_size == cache.max_size
+
+    # Test that copying object not just reference by mutating a value in the copy
+    copy(cache)["c"] = [3]
+    @test cache.cache == Dict{String, Vector{Int64}}("a" => [1], "b" => [2])
+
+    # Test that it is shallow copying
+    value_for_a = copy(cache)["a"]
+    push!(value_for_a, 1)
+    @test cache.cache == Dict{String, Vector{Int64}}("a" => [1, 1], "b" => [2])
+    @test cache.priority == ["a", "b"]
+end
+
+@testset "deepcopy" begin
+    cache = DataStructures.LRUCache{String, Vector{Int64}}(max_size = 3)
+    cache["a"] = [1]
+    cache["b"] = [2]
+
+    # Test copy for equivalence
+    @test deepcopy(cache).priority == cache.priority
+    @test deepcopy(cache).cache == cache.cache
+    @test deepcopy(cache).max_size == cache.max_size
+
+    # Test that it is deep copying
+    value_for_a = deepcopy(cache)["a"]
+    push!(value_for_a, 1)
+    @test cache.cache == Dict{String, Vector{Int64}}("a" => [1], "b" => [2])
+    @test cache.priority == ["a", "b"]
+end
+
+@testset "empty LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache["a"] = 1
+    cache["b"] = 2
+
+    # Test that it is returning a new empty LRUcache
+    empty_cache = empty(cache)
+    @test empty_cache != cache
+
+    # Test that if not specified, key and value types are copied
+    @test empty_cache.cache == Dict{String, Int64}()
+    @test empty_cache.cache isa Dict{String, Int64}
+    @test empty_cache.priority == []
+    @test empty_cache.max_size == cache.max_size
+
+    # Test empty if a second arg is given
+    empty_cache = empty(cache, Char)
+    @test empty_cache.cache == Dict{String, Char}()
+    @test empty_cache.cache isa Dict{String, Char}
+    @test empty_cache.priority isa Vector{String}
+
+    # Test empty if two args are given
+    empty_cache = empty(cache, Int64, String)
+    @test empty_cache.cache == Dict{Int64, String}()
+    @test empty_cache.cache isa Dict{Int64, String}
+    @test empty_cache.priority isa Vector{Int64}
+end
+
+@testset "empty! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache["a"] = 1
+    cache["b"] = 2
+
+    # Test that it is emptying LRUcache
+    @test empty!(cache).cache == Dict{String, Int64}()
+    @test cache.cache == Dict{String, Int64}()
+    @test cache.cache isa Dict{String, Int64}
+    @test cache.priority == []
+
+    # Test that it is not returning a copy
+    empty!(cache)["c"] = 3
+    @test cache.cache == Dict{String, Int64}("c" => 3)
+end
+
+@testset "pop! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Test that it deletes and returns mapping for key if in cache
+    @test pop!(cache, "b") == 2
+    @test cache.cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+
+    # Test popping key that doesn't exist without specifying default throws error
+    @test_throws KeyError pop!(cache, "b")
+
+    # Test that default returned if key not in cache
+    @test pop!(cache, "b", 5) == 5
+end
+
+@testset "delete! LRU" begin
+    cache = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache["a"] = 1
+    cache["b"] = 2
+    cache["c"] = 3
+
+    # Test when key in cache, that it deletes and returns the cache
+    @test delete!(cache, "b") isa DataStructures.LRUCache
+    @test cache.cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+
+    # Test that deleting key that isn't in cache just returns the cache
+    @test delete!(cache, "b").cache == Dict{String, Int64}("a" => 1, "c" => 3)
+    @test cache.priority == ["a", "c"]
+end
+
+@testset "merge LRU" begin
+    cache1 = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache1["a"] = 1
+    cache1["b"] = 2
+    cache2 = DataStructures.LRUCache{String, Int64}(max_size = 3)
+    cache2["c"] = 3
+    cache2["a"] = 4
+
+    # Test merging two LRUcaches throws error
+    @test_throws ErrorException merge(cache1, cache2)
 end


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Adds expected Dict methods to LRUCache
Closes #79  -- this will automatically close issue 79 on PR merge



## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content

Add haskey, copy, deepcopy, empty, empty!, get, pop!, getindex, setindex!, and delete! methods to LRUCache



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
