### PR TITLE
Fix show for `LRUCache`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+v0.1.13
+-------
+
+- Fix `show` for `LRUCache` (and `iterate` with a state). PR
+  [#96](https://github.com/CliMA/ClimaUtilities.jl/pull/96)
+
 v0.1.12
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.12"
+version = "0.1.13"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/DataStructures.jl
+++ b/src/DataStructures.jl
@@ -119,7 +119,7 @@ function Base.:(==)(
 end
 
 """
-    iterate(cache::LRUCache{K, V})
+    iterate(cache::LRUCache{K, V} [, state])
 
 Advance the iterator to obtain the next element. If no elements remain, nothing
 should be returned. Otherwise, a 2-tuple of the next element and the new
@@ -127,6 +127,10 @@ iteration state should be returned.
 """
 function Base.iterate(cache::LRUCache{K, V}) where {K, V}
     return iterate(cache.cache)
+end
+
+function Base.iterate(cache::LRUCache{K, V}, state) where {K, V}
+    return iterate(cache.cache, state)
 end
 
 """


### PR DESCRIPTION
`show` uses `iterate` with a state, which was missing. This commits adds it, restoring `show`.
