### PR TITLE
Improve handling of floatin gpoint errors in DataHandling times

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,12 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+v0.1.14
+-------
+
+- Reduce floating point errors in times for DataHandling. PR
+  [#101](https://github.com/CliMA/ClimaUtilities.jl/pull/101)
+
 v0.1.13
 -------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.13"
+version = "0.1.14"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -253,9 +253,13 @@ function DataHandling.time_to_date(
     data_handler::DataHandler,
     time::AbstractFloat,
 )
-    # We go through nanoseconds to allow fractions of a second (otherwise, Second(0.8) would fail)
-    time_ns = Dates.Nanosecond(1_000_000_000 * (data_handler.t_start + time))
-    return data_handler.reference_date + time_ns
+    # We go through milliseconds to allow fractions of a second (otherwise, Second(0.8)
+    # would fail). Milliseconds is the level of resolution that one gets when taking the
+    # difference between two DateTimes. In addition to this, we add a round to account for
+    # floating point errors. If the floating point error is small enough, round will correct
+    # it.
+    time_ms = Dates.Millisecond(round(1_000 * (data_handler.t_start + time)))
+    return data_handler.reference_date + time_ms
 end
 
 """


### PR DESCRIPTION
This bug was found while working with ozone data. Ozone data is defined at non-clean times, eg 2010-07-17T14:11:30.422, and was leading to failures.

The reason for failures are due to moving between times and dates, with times being represented as floating points.

For Float64, times of order of O(few) years (~ 1e7-1e8 seconds) have errors of O(1-100) nanoseconds. As a result, dates like
2010-07-17T14:11:30.422 can be misresolved to 2010-07-17T14:11:30.421 or 2010-07-17T14:11:30.423 when computed from a time. This results in errors because data that is expected to be found is not found.

As a workaround, this commit truncates processing to Milliseconds (because Milliseconds is the time resolution in DateTime) and adds a round operation to recover that resolution.

It is still possible for this workaround to fail: if the floating point error is very large, the round operation might round in the wrong direction.

Closes #99 