### PR TITLE
Remove t_start, rename reference_date->start_date

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,30 +3,40 @@ ClimaUtilities.jl Release Notes
 
 main
 -------
-- [Feature] Add support for composing input variables.
-  PR [#105](https://github.com/CliMA/ClimaUtilities.jl/pull/105/)
 
-  This allows a list of `varnames` (and possibly `file_paths`) to be
-  passed to `TimeVaryingInput` or `SpaceVaryingInput`, along with a
-  `compose_function` to compose them, as so:
+### Features
 
-  ```julia
-  # Define the pointwise composing function we want, a simple sum in this case
-  compose_function = (x, y) -> x + y
-  # Define pre-processing function to convert units of input
-  unit_conversion_func = (data) -> 1000 * data
+Added support for composing input variables. PR
+[#105](https://github.com/CliMA/ClimaUtilities.jl/pull/105/)
 
-  data_handler = TimeVaryingInputs.TimeVaryingInput("era5_example.nc",
-                                          ["u", "v"],
-                                          target_space,
-                                          reference_date = Dates.DateTime(2000, 1, 1),
-                                          regridder_type = :InterpolationsRegridder,
-                                          file_reader_kwargs = (; preprocess_func = unit_conversion_func),
-                                          compose_function)
-  ```
+This allows a list of `varnames` (and possibly `file_paths`) to be passed to
+`TimeVaryingInput` or `SpaceVaryingInput`, along with a `compose_function` to
+compose them, as so:
 
-  See the `TimeVaryingInput` or `DataHandler` docs "NetCDF file input"
-  sections for more details.
+```julia
+# Define the pointwise composing function we want, a simple sum in this case
+compose_function = (x, y) -> x + y
+# Define pre-processing function to convert units of input
+unit_conversion_func = (data) -> 1000 * data
+
+data_handler = TimeVaryingInputs.TimeVaryingInput("era5_example.nc",
+                                        ["u", "v"],
+                                        target_space,
+                                        start_date = Dates.DateTime(2000, 1, 1),
+                                        regridder_type = :InterpolationsRegridder,
+                                        file_reader_kwargs = (; preprocess_func = unit_conversion_func),
+                                        compose_function)
+```
+
+See the `TimeVaryingInput` or `DataHandler` docs "NetCDF file input" sections
+for more details.
+
+### Deprecations
+
+`reference_date` was renamed to `start_date` and `t_start` was dropped from
+the constructors for `DataHandler` and `TimeVaryingInput`.
+
+These changes are due to the fact that these arguments should not be needed.
 
 v0.1.14
 -------

--- a/docs/src/datahandling.md
+++ b/docs/src/datahandling.md
@@ -88,12 +88,12 @@ unit_conversion_func = (data) -> 1000 * data
 data_handler = DataHandling.DataHandler("era5_example.nc",
                                         "u",
                                         target_space,
-                                        reference_date = Dates.DateTime(2000, 1, 1),
+                                        start_date = Dates.DateTime(2000, 1, 1),
                                         regridder_type = :InterpolationsRegridder,
                                         file_reader_kwargs = (; preprocess_func = unit_conversion_func))
 
 function linear_interpolation(data_handler, time)
-    # Time is assumed to be "simulation time", ie seconds starting from reference_date
+    # Time is assumed to be "simulation time", ie seconds starting from start_date
 
     time_of_prev_snapshot = DataHandling.previous_time(data_handler, time)
     time_of_next_snapshot = DataHandling.next_time(data_handler, time)
@@ -125,7 +125,7 @@ compose_function = (x, y) -> x + y
 data_handler = DataHandling.DataHandler("era5_example.nc",
                                         ["u", "v"],
                                         target_space,
-                                        reference_date = Dates.DateTime(2000, 1, 1),
+                                        start_date = Dates.DateTime(2000, 1, 1),
                                         regridder_type = :InterpolationsRegridder,
                                         file_reader_kwargs = (; preprocess_func = unit_conversion_func),
                                         compose_function)

--- a/docs/src/faqs.md
+++ b/docs/src/faqs.md
@@ -19,11 +19,11 @@ import Interpolations
 # Loading ClimaCore, NCDatasets, Interpolations loads the extensions we need
 
 # target_space is defined somewhere and is our computational grid
-# reference_date is the simulation date
+# start_date is the simulation date
 
 distance_tv = TimeVaryingInputs.TimeVaryingInput("distances.nc",
                                                   "distance",
                                                   target_space;
-                                                  reference_date,
+                                                  start_date,
                                                   file_reader_kwargs = (; preprocess_func = x -> 10x))
 ```

--- a/docs/src/inputs.md
+++ b/docs/src/inputs.md
@@ -79,13 +79,13 @@ unit_conversion_func = (data) -> 1000 * data
 data_handler = TimeVaryingInputs.TimeVaryingInput("era5_example.nc",
                                         ["u", "v"],
                                         target_space,
-                                        reference_date = Dates.DateTime(2000, 1, 1),
+                                        start_date = Dates.DateTime(2000, 1, 1),
                                         regridder_type = :InterpolationsRegridder,
                                         file_reader_kwargs = (; preprocess_func = unit_conversion_func),
                                         compose_function)
 ```
 
-The same arguments (excluding `reference_date`) could be passed to a
+The same arguments (excluding `start_date`) could be passed to a
 `SpaceVaryingInput` to compose multiple input variables with that type.
 
 ### Extrapolation boundary conditions
@@ -165,10 +165,10 @@ albedo_tv_an = TimeVaryingInput((t) -> 0.5)
 
 # If the albedo comes from data
 
-# reference_date is the calendar date at the beginning of our simulation
-reference_date = Dates.DateTime(2000, 1, 1)
+# start_date is the calendar date at the beginning of our simulation
+start_date = Dates.DateTime(2000, 1, 1)
 albedo_tv = TimeVaryingInputs.TimeVaryingInput("cesem_albedo.nc", "alb", target_space;
-                                               reference_date, regridder_kwargs = (; regrid_dir = "/tmp"))
+                                               start_date, regridder_kwargs = (; regrid_dir = "/tmp"))
 # When using data from files, the data is automatically interpolated to the correct
 # time
 
@@ -182,7 +182,7 @@ to other constructors. This often used to preprocess files that are being read
 by a factor of 100, we would change `albedo_tv` with
 ```julia
 albedo_tv = TimeVaryingInputs.TimeVaryingInput("cesem_albedo.nc", "alb", target_space;
-                                               reference_date, regridder_kwargs = (; regrid_dir = "/tmp"),
+                                               start_date, regridder_kwargs = (; regrid_dir = "/tmp"),
                                                file_reader_kwargs = (; preprocess_func = (x) -> 100x))
 ```
 

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -144,19 +144,34 @@ function TimeVaryingInputs.TimeVaryingInput(
     varnames::Union{AbstractString, AbstractArray{<:AbstractString}},
     target_space::ClimaCore.Spaces.AbstractSpace;
     method = LinearInterpolation(),
-    reference_date::Dates.DateTime = Dates.DateTime(1979, 1, 1),
-    t_start::AbstractFloat = 0.0,
+    start_date::Union{Dates.DateTime, Dates.Date} = Dates.DateTime(1979, 1, 1),
     regridder_type = nothing,
     regridder_kwargs = (),
     file_reader_kwargs = (),
     compose_function = identity,
+    ########### DEPRECATED ###############
+    reference_date = nothing,
+    t_start = nothing,
+    ########### DEPRECATED ###############
 )
+    ########### DEPRECATED ###############
+    if !isnothing(reference_date)
+        start_date = reference_date
+        Base.depwarn(
+            "The keyword argument `reference_date` is deprecated. Use `start_date` instead.",
+            :TimeVaryingInput,
+        )
+    end
+    if !isnothing(t_start)
+        Base.depwarn("`t_start` was removed will be ignored", :TimeVaryingInput)
+    end
+    ########### DEPRECATED ###############
+
     data_handler = DataHandling.DataHandler(
         file_paths,
         varnames,
         target_space;
-        reference_date,
-        t_start,
+        start_date,
         regridder_type,
         regridder_kwargs,
         file_reader_kwargs,

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -243,15 +243,14 @@ end
                 data_handler = DataHandling.DataHandler(
                     PATH,
                     varname,
-                    target_space,
-                    reference_date = Dates.DateTime(2000, 1, 1),
-                    t_start = 0.0;
+                    target_space;
+                    start_date = Dates.DateTime(2000, 1, 1),
                     regridder_type,
                 )
 
                 @test DataHandling.available_dates(data_handler) ==
                       data_handler.file_readers[varname].available_dates
-                @test data_handler.reference_date .+
+                @test data_handler.start_date .+
                       Second.(DataHandling.available_times(data_handler)) ==
                       DataHandling.available_dates(data_handler)
 
@@ -262,17 +261,17 @@ end
                       available_times[2] - available_times[1]
 
                 @test DataHandling.time_to_date(data_handler, 0.0) ==
-                      data_handler.reference_date
+                      data_handler.start_date
                 @test DataHandling.time_to_date(data_handler, 1.0) ==
-                      data_handler.reference_date + Second(1)
+                      data_handler.start_date + Second(1)
 
                 @test DataHandling.date_to_time(
                     data_handler,
-                    data_handler.reference_date,
-                ) == data_handler.t_start
+                    data_handler.start_date,
+                ) == 0.0
                 @test DataHandling.date_to_time(
                     data_handler,
-                    data_handler.reference_date + Second(1),
+                    data_handler.start_date + Second(1),
                 ) == 1.0
 
                 # Previous time with time

--- a/test/time_varying_inputs23.jl
+++ b/test/time_varying_inputs23.jl
@@ -46,8 +46,7 @@ include("TestTools.jl")
                     PATH,
                     "u10n",
                     target_space;
-                    reference_date = Dates.DateTime(2021, 1, 1, 1),
-                    t_start = 0.0,
+                    start_date = Dates.DateTime(2021, 1, 1, 1),
                     regridder_type,
                 )
 
@@ -58,7 +57,7 @@ include("TestTools.jl")
                     PATH,
                     ["u10n", "t2m"],
                     target_space;
-                    reference_date = Dates.DateTime(2021, 1, 1, 1),
+                    start_date = Dates.DateTime(2021, 1, 1, 1),
                     t_start = 0.0,
                     regridder_type = regridder_type_interp,
                     compose_function,
@@ -68,8 +67,7 @@ include("TestTools.jl")
                     PATH,
                     "u10n",
                     target_space;
-                    reference_date = Dates.DateTime(2021, 1, 1, 1),
-                    t_start = 0.0,
+                    start_date = Dates.DateTime(2021, 1, 1, 1),
                     regridder_type,
                     method = TimeVaryingInputs.NearestNeighbor(),
                 )
@@ -78,8 +76,7 @@ include("TestTools.jl")
                     PATH,
                     "u10n",
                     target_space;
-                    reference_date = Dates.DateTime(2021, 1, 1, 1),
-                    t_start = 0.0,
+                    start_date = Dates.DateTime(2021, 1, 1, 1),
                     regridder_type,
                     method = TimeVaryingInputs.NearestNeighbor(
                         TimeVaryingInputs.Flat(),
@@ -91,8 +88,7 @@ include("TestTools.jl")
                         PATH,
                         "u10n",
                         target_space;
-                        reference_date = Dates.DateTime(2021, 1, 1, 1),
-                        t_start = 0.0,
+                        start_date = Dates.DateTime(2021, 1, 1, 1),
                         regridder_type,
                         method = TimeVaryingInputs.NearestNeighbor(
                             TimeVaryingInputs.PeriodicCalendar(),
@@ -104,8 +100,7 @@ include("TestTools.jl")
                         PATH,
                         "u10n",
                         target_space;
-                        reference_date = Dates.DateTime(2021, 1, 1, 1),
-                        t_start = 0.0,
+                        start_date = Dates.DateTime(2021, 1, 1, 1),
                         regridder_type,
                         method = TimeVaryingInputs.LinearInterpolation(
                             TimeVaryingInputs.PeriodicCalendar(),
@@ -123,8 +118,7 @@ include("TestTools.jl")
                         PATH,
                         "u10n",
                         target_space;
-                        reference_date = Dates.DateTime(2021, 1, 1, 1),
-                        t_start = 0.0,
+                        start_date = Dates.DateTime(2021, 1, 1, 1),
                         regridder_type,
                         method = TimeVaryingInputs.NearestNeighbor(
                             TimeVaryingInputs.PeriodicCalendar(
@@ -139,8 +133,7 @@ include("TestTools.jl")
                         PATH,
                         "u10n",
                         target_space;
-                        reference_date = Dates.DateTime(2021, 1, 1, 1),
-                        t_start = 0.0,
+                        start_date = Dates.DateTime(2021, 1, 1, 1),
                         regridder_type,
                         method = TimeVaryingInputs.LinearInterpolation(
                             TimeVaryingInputs.PeriodicCalendar(

--- a/test/time_varying_inputs_linearperiodfilling.jl
+++ b/test/time_varying_inputs_linearperiodfilling.jl
@@ -89,13 +89,9 @@ include("TestTools.jl")
             DateTime(1995, 1, 6),
             DateTime(1995, 12, 11),
         ]
-        reference_date = DateTime(1985, 1, 1)
-        t_start = 0.0
+        start_date = DateTime(1985, 1, 1)
 
-        times = map(
-            d -> period_to_seconds_float(d - reference_date) - t_start,
-            dates,
-        )
+        times = map(d -> period_to_seconds_float(d - start_date), dates)
 
         ones_array = ones(Float64, (3, 3))
 
@@ -124,8 +120,7 @@ include("TestTools.jl")
             data_path,
             "data",
             target_space;
-            reference_date,
-            t_start,
+            start_date,
             regridder_type,
         )
 


### PR DESCRIPTION
`t_start` and `reference_date` were added following an incorrect assumption (that restarts would restart at t = 0). The names were taken from ClimaLand/ClimaCouper, where these variables were used slightly differently (`reference_date` might have been the first date available in a file, and `t_start` allowed to run at at different point in that file).

Passing Land build: https://buildkite.com/clima/climaland-ci/builds/5083
