### PR TITLE
Reduce allocations due to isequispaced

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ ClimaUtilities.jl Release Notes
 main
 ------
 
+main
+-------
+
+### Bug fixes
+
+`Utils.isequispaced` is now more efficient: it fails fast and does not allocate
+as much. More redundant allocations due to `Utils.isequispaced` were fixed.
 
 v0.1.15
 -------

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -219,9 +219,6 @@ function _time_range_dt_dt_e(
     itp::InterpolatingTimeVaryingInput23D,
     extrapolation_bc::PeriodicCalendar{Nothing},
 )
-    isequispaced(DataHandling.available_times(itp.data_handler)) || error(
-        "PeriodicCalendar() boundary condition cannot be used because data is defined at non uniform intervals of time",
-    )     # Here for good measure
     dt = DataHandling.dt(itp.data_handler)
     return itp.range[begin], itp.range[end], dt, dt / 2
 end

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -97,8 +97,13 @@ function isequispaced(
     tol = eltype(v) <: AbstractFloat ? sqrt(eps(eltype(v))) : eps(),
 )
     length(v) < 2 && return true
-    diffs = diff(v)
-    return all(abs(d - diffs[begin]) < tol for d in diffs)
+    dv = v[begin + 1] - v[begin]
+    @inbounds for i in 2:length(v)
+        if abs(v[i] - v[i - 1] - dv) > tol
+            return false
+        end
+    end
+    return true
 end
 
 """


### PR DESCRIPTION
`Utils.isequispaced` is now more efficient: it fails fast and does not allocate as much. More redundant allocations due to `Utils.isequispaced` were fixed.
