### PR TITLE
Add read! function

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -12,6 +12,12 @@ main
 `Utils.isequispaced` is now more efficient: it fails fast and does not allocate
 as much. More redundant allocations due to `Utils.isequispaced` were fixed.
 
+### Features
+
+- Reduced allocations in regridding. New method `read!`.
+Existing `read` now returns a copy of the data when returning from the cache.
+PR [#119](https://github.com/CliMA/ClimaUtilities.jl/pull/119)
+
 v0.1.15
 -------
 

--- a/docs/src/filereaders.md
+++ b/docs/src/filereaders.md
@@ -23,9 +23,10 @@ The only file reader currently implemented is the `NCFileReader`, used to read
 NetCDF files. Each `NCFileReader` is associated to one particular file and
 variable (but multiple `NCFileReader`s can share the same file).
 
-Once created, `NCFileReader` is accessed with the `read(file_reader, date)`
+Once created, `NCFileReader` is accessed with the `read!(file_reader, date)`
 function, which returns the `Array` associated to given `date` (if available).
-The `date` can be omitted if the data is static.
+The `date` can be omitted if the data is static. The data is stored in a
+preallocated array so it can be accessed multiple times without reallocating.
 
 `NCFileReader`s implement two additional features: (1) optional preprocessing,
 and (2) cache reads. `NCFileReader`s can be created with a `preprocessing_func`
@@ -78,6 +79,7 @@ close(v_var)
 ```@docs
 ClimaUtilities.FileReaders.NCFileReader
 ClimaUtilities.FileReaders.read
+ClimaUtilities.FileReaders.read!
 ClimaUtilities.FileReaders.available_dates
 ClimaUtilities.FileReaders.close_all_ncfiles
 Base.close

--- a/src/FileReaders.jl
+++ b/src/FileReaders.jl
@@ -17,6 +17,8 @@ function NCFileReader end
 
 function read end
 
+function read! end
+
 function available_dates end
 
 function close_all_ncfiles end

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -37,6 +37,12 @@ using NCDatasets
         @test FileReaders.read(ncreader_u, DateTime(2021, 01, 01, 01)) ==
               nc["u10n"][:, :, 2]
 
+        # Test read!
+        dest = copy(nc["u10n"][:, :, 2])
+        fill!(dest, 0)
+        FileReaders.read!(dest, ncreader_u, DateTime(2021, 01, 01, 01))
+        @test dest == nc["u10n"][:, :, 2]
+
         # Test that we need to close all the variables to close the file
         open_ncfiles =
             Base.get_extension(
@@ -72,6 +78,12 @@ end
         @test ncreader.dimensions[2] == nc["lat"][:]
 
         @test FileReaders.read(ncreader) == nc["u10n"][:, :]
+
+        # Test read!
+        dest = copy(nc["u10n"][:, :])
+        fill!(dest, 0)
+        FileReaders.read!(dest, ncreader)
+        @test dest == nc["u10n"][:, :]
 
         @test isempty(FileReaders.available_dates(ncreader))
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Adds a new function `read!` that reads in data to a preallocated space in the DataHandler, as opposed to allocating at each call as the existing `read` does. This requires the addition of a `preallocated_read_data` cache to the `DataHandler` object. 

It also requires that `read` returns a copy of the data in the case of a cache hit to avoid overwriting data in the cache (this was the cause of the bug in the original implementation).

Note that we expect higher allocations when using `read` due to the added `copy`, but lower allocations using `read!` over `read`. Internally, we now use `read!` now so users should see reduced allocations.

This feature was initially introduced in https://github.com/CliMA/ClimaUtilities.jl/pull/83/, but there was a bug in that implementation so it has been reworked here

closes #81 