### PR TITLE
Fix clima_artifact for Julia 1.12

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,7 @@ jobs:
           - '1.9'
           - '1.10'
           - '1.11'
+          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,13 @@
 ClimaUtilities.jl Release Notes
 ===============================
 
+main
+------
+
+### Bug fixes
+
+- Fixed `@clima_artifact` for Julia 1.12. PR [#123](https://github.com/CliMA/ClimaUtilities.jl/pull/123)
+
 v0.1.17
 ------
 

--- a/src/ClimaArtifacts.jl
+++ b/src/ClimaArtifacts.jl
@@ -105,6 +105,12 @@ macro clima_artifact(name, context = nothing)
         # If artifact_name is not a string (e.g., it is a variable), we have to do all the
         # work at runtime
         return quote
+            if VERSION >= v"1.12.0-DEV.1163"
+                local LazyArtifacts = Val($(lazyartifacts))
+            else
+                local LazyArtifacts = $(lazyartifacts)
+            end
+
             local platform = $(esc(platform))
             local artifact_name, artifact_path_tail, hash =
                 JuliaArtifacts.artifact_slash_lookup(
@@ -126,7 +132,7 @@ macro clima_artifact(name, context = nothing)
                     $(artifact_dict),
                     $(hash),
                     $(platform),
-                    $(lazyartifacts),
+                    LazyArtifacts,
                 )::String
             end
             push!(ACCESSED_ARTIFACTS, artifact_name)
@@ -139,13 +145,19 @@ macro clima_artifact(name, context = nothing)
                 $(artifact_dict),
                 $(hash),
                 $(platform),
-                $(lazyartifacts),
+                LazyArtifacts,
             )::String
         end
     else
         # If artifact_name is not a string (e.g., it is a variable), we have to do all the
         # work at runtime
         return quote
+            if VERSION >= v"1.12.0-DEV.1163"
+                local LazyArtifacts = Val($(lazyartifacts))
+            else
+                local LazyArtifacts = $(lazyartifacts)
+            end
+
             local platform = $(esc(platform))
             local artifact_name, artifact_path_tail, hash =
                 JuliaArtifacts.artifact_slash_lookup(
@@ -179,7 +191,7 @@ macro clima_artifact(name, context = nothing)
                     $(artifact_dict),
                     hash,
                     platform,
-                    $(lazyartifacts),
+                    LazyArtifacts,
                 )::String
             end
             push!(ACCESSED_ARTIFACTS, artifact_name)
@@ -193,7 +205,7 @@ macro clima_artifact(name, context = nothing)
                 $(artifact_dict),
                 hash,
                 platform,
-                $(lazyartifacts),
+                LazyArtifacts,
             )::String
         end
     end


### PR DESCRIPTION
https://github.com/JuliaLang/julia/commit/e95eeddb30737962791f51e637dabdfe38c1a9bc changed some internal types in `_artifact_str`, so that `@clima_artifact` stopped working. This fixes it.

Closes #117 
