### PR TITLE
Expand error message and sleep time in maybe_wait

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,9 +4,16 @@ ClimaUtilities.jl Release Notes
 main
 ------
 
+v0.1.18
+------
+
 ### Bug fixes
 
 - Fixed `@clima_artifact` for Julia 1.12. PR [#123](https://github.com/CliMA/ClimaUtilities.jl/pull/123)
+- Increased sleep time across attempts in checking for synced filesystems. This
+  should give the distributed filesystems more time to sync and reduce the
+  occurrence of the "Path not properly synced" error. PR
+  [#125](https://github.com/CliMA/ClimaUtilities.jl/pull/125)
 
 v0.1.17
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.17"
+version = "0.1.18"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/src/OutputPathGenerator.jl
+++ b/src/OutputPathGenerator.jl
@@ -26,7 +26,7 @@ Distributed filesystems might need some time to catch up a file/folder is create
 
 This function watches the given `path` with `check_func` and returns when `check_func(path)`
 returns true. This is done by trying up to `max_attempt` times and sleeping `sleep_time`
-seconds in between.
+seconds in between. `sleep_time` is increased by 50 % after each attempt.
 
 Example: when creating a file, we want to check that all the MPI processes see that new
 file. In this case, `check_func` could be `ispath`. Another example is with removing files
@@ -45,8 +45,12 @@ function maybe_wait_filesystem(
         check_func(path) && return nothing
         sleep(sleep_time)
         attempt = attempt + 1
+        sleep_time = 1.5sleep_time
     end
-    error("Path $path not properly synced")
+    error(
+        "Path $path not properly synced. On distributed systems, this is typically due to the slow response of the filesystem." *
+        " We waited for a few seconds and tried multiple times, but different MPI processes still disagree on the state of the filesystem. Aborting.",
+    )
     return nothing
 end
 
@@ -177,12 +181,12 @@ function generate_output_path(::ActiveLinkStyle, output_path; context = nothing)
     # For MPI runs, we have to make sure we are synced
     maybe_wait_filesystem(context, output_path)
 
+    name_rx = r"output_(\d\d\d\d)"
+
     # Look for a output_active link
     active_link = joinpath(output_path, "output_active")
 
     link_exists = islink(active_link)
-
-    name_rx = r"output_(\d\d\d\d)"
 
     if link_exists
         target = readlink(active_link)


### PR DESCRIPTION
This commit increases sleep time across attempts in checking for synced filesystems. This should give the distributed filesystems more time to sync and reduce the occurrence of the "Path not properly synced" error.

Before, the maximum allowed time was 1 second with attempts every 0.1, now it 6 seconds, with exponential backoff.
