### PR TITLE
Reduce default max cache size for DataHandlers

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -43,6 +43,12 @@ to learn more about this.
 
 This capability is only available for the `InterpolationsRegridder`.
 
+#### Reduced default size of cache in `DataHandler`. PR [#133](https://github.com/CliMA/ClimaUtilities.jl/pull/133)
+
+The default cache size for regridded fields in `DataHandler` was reduced from
+128 to 2, reducing the memory footprint. You can pass the `cache_max_size`
+keyword argument to control this value.
+
 v0.1.19
 ------
 

--- a/docs/src/datastructures.md
+++ b/docs/src/datastructures.md
@@ -32,7 +32,7 @@ cache = DataStructures.LRUCache{Int, Int}(; max_size = 128)
 ```
 
 Once we have the `cache`, we can access and insert elements with `get!`.
-`get!` retrieves the value associated to the key if avaialble, otherwise
+`get!` retrieves the value associated to the key if available, otherwise
 it inserts a new key with a provided default. The default can be passed as
 third argument or can be the return statement of a function provided as
 first (as typically done in `do` blocks). Continuing the example above

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -130,7 +130,7 @@ end
                 target_space::ClimaCore.Spaces.AbstractSpace;
                 start_date::Dates.DateTime = Dates.DateTime(1979, 1, 1),
                 regridder_type = nothing,
-                cache_max_size::Int = 128,
+                cache_max_size::Int = 2,
                 regridder_kwargs = (),
                 file_reader_kwargs = ())
 
@@ -144,7 +144,9 @@ different files.
 the latter case, the entries of `file_paths` and `varnames` are expected to match based on
 position.
 
-The DataHandler maintains an LRU cache of Fields that were previously computed.
+The DataHandler maintains an LRU cache of Fields that were previously computed. The default
+size for the cache is only two fields, so if you expect to re-use the same fields often,
+increasing the cache size can lead to improved performances.
 
 Creating this object results in the file being accessed (to preallocate some memory).
 
@@ -202,7 +204,7 @@ function DataHandling.DataHandler(
     target_space::ClimaCore.Spaces.AbstractSpace;
     start_date::Union{Dates.DateTime, Dates.Date} = Dates.DateTime(1979, 1, 1),
     regridder_type = nothing,
-    cache_max_size::Int = 128,
+    cache_max_size::Int = 2,
     regridder_kwargs = (),
     file_reader_kwargs = (),
     compose_function = identity,


### PR DESCRIPTION
This should reduce the memory footprint for long simulations
