### PR TITLE
Add OnlineLogging

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,30 @@ main
 v0.1.20
 ------
 
+#### New module `OnlineLogging`. PR [#137](https://github.com/CliMA/ClimaUtilities.jl/pull/137)
+
+A new module, `OnlineLogging`, provides tools to report messages while a
+simulation is running. Currently, the only feature implemented is
+`WallTimeInfo`, to report on timing information.
+
+With `WallTimeInfo`, one can add reports like the following to their simulations
+```
+┌ Info: Progress
+│   simulation_time = "2 seconds"
+│   n_steps_completed = 20
+│   wall_time_per_step = "10 milliseconds, 100 microseconds"
+│   wall_time_total = "1 second, 10 milliseconds"
+│   wall_time_remaining = "808 milliseconds, 35 microseconds"
+│   wall_time_spent = "202 milliseconds, 8 microseconds"
+│   percent_complete = "20.0%"
+│   estimated_sypd = "0.027"
+│   date_now = 2024-12-03T16:01:13.660
+└   estimated_finish_date = 2024-12-03T16:01:14.660
+```
+
+Find more information in the
+[documentation](https://clima.github.io/ClimaUtilities.jl/dev/onlinelogging.html).
+
 #### Support reading time data across multiple files. PRs [#127](https://github.com/CliMA/ClimaUtilities.jl/pull/127), [#132](https://github.com/CliMA/ClimaUtilities.jl/pull/132)
 
 `NCFileReader`s can now read multiple files at the same time. The files have to

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ ClimaUtilities.jl
   [`DataHandling`](https://clima.github.io/ClimaUtilities.jl/dev/datahandling/),
   and [`Regridders`](https://clima.github.io/ClimaUtilities.jl/dev/regridders/)
   to process input data and remap it onto the simulation grid.
+- [`OnlineLogging`](https://clima.github.io/ClimaUtilities.jl/dev/onlinelogging/)
+  to add output information while a simulation is running.
 - [`OutputPathGenerator`](https://clima.github.io/ClimaUtilities.jl/dev/outputpathgenerator/)
   to prepare the output directory structure of a simulation.
 - [`TimeManager`](https://clima.github.io/ClimaUtilities.jl/dev/timemanager/) to

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -23,6 +23,7 @@ pages = [
     "FileReaders" => "filereaders.md",
     "DataHandling" => "datahandling.md",
     "Regridders" => "regridders.md",
+    "OnlineLogging" => "onlinelogging.md",
     "OutputPathGenerator" => "outputpathgenerator.md",
     "TimeManager" => "timemanager.md",
     "Frequently Asked Questions" => "faqs.md",

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -60,6 +60,11 @@ conservative interpolation onto lat-long grids.
     At the moment, `TempestRegridder` *does not* support MPI/GPUs and can
     only perform interpolation onto lat-long grids (not on z).
 
+### `OnlineLogging`
+
+`OnlineLogging` provides tools to produce informative messages while a
+simulation is running (e.g., current/average timing information).
+
 ### `OutputPathGenerator`
 
 `OutputPathGenerator` handles the directory structure for the output of a

--- a/docs/src/onlinelogging.md
+++ b/docs/src/onlinelogging.md
@@ -1,0 +1,89 @@
+# Online Simulation Progress Reporting
+
+The `OnlineLogging` module provides tools to monitor and report the simulation
+progress and other information of simulations.
+
+Currently, the only feature implemented is timing report, to print information
+about current step, simulation time, and average performance. With
+`report_walltime`, you will see progress information like the following
+```
+┌ Info: Progress
+│   simulation_time = "2 seconds"
+│   n_steps_completed = 20
+│   wall_time_per_step = "10 milliseconds, 100 microseconds"
+│   wall_time_total = "1 second, 10 milliseconds"
+│   wall_time_remaining = "808 milliseconds, 35 microseconds"
+│   wall_time_spent = "202 milliseconds, 8 microseconds"
+│   percent_complete = "20.0%"
+│   estimated_sypd = "0.027"
+│   date_now = 2024-12-03T16:01:13.660
+└   estimated_finish_date = 2024-12-03T16:01:14.660
+```
+
+## `WallTimeInfo` and `report_walltime`
+
+`WallTimeInfo` is a struct that holds information about wall time (the time you
+see on your watch, not the simulation time) and that can be used to report
+timing information with [`report_walltime`](@ref).
+
+`WallTimeInfo` keeps track and accumulates how much time has elapsed since the
+last time it was updated. In this, `WallTimeInfo` tries to automatically remove
+the compilation overhead that your simulation might run into in the first step
+(this is accomplished by ignoring the first step and doubling the cost of the
+second step to compensate).
+
+The simplest way to use `WallTimeInfo` is to make `report_walltime` a callback.
+Here is an example using a `SciML` integrator
+```julia
+import SciMLBase
+import ClimaUtilities.OnlineLogging: WallTimeInfo, report_walltime
+# Create the WallTimeInfo
+wt = WallTimeInfo()
+
+# Define a schedule that defines how often to report. Here, we follow the signature
+# required by SciML. This function is triggered every 10 steps
+function every10steps(u, t, integrator)
+    return mod(integrator.step, 10) == 0
+end
+
+# Next, define the callback
+report_callback = SciMLBase.DiscreteCallback(every10steps,
+    let wt = wt
+        integrator -> report_walltime(wt, integrator)
+    end)
+
+# The let wt = wt is not strickly required, but it can improve type-stability and performance
+
+# Now that we have the callback, we can pass it to the SciML constructor for the integrator
+```
+
+!!! todo
+
+    Describe schedules when we add them to `ClimaUtilities`
+
+The `report_walltime` function prints various timing statistics:
+
+* **`simulation_time`:** The elapsed time within the simulation.
+* **`n_steps_completed`:** The number of simulation steps completed.
+* **`wall_time_per_step`:** The average wall clock time per step.
+* **`wall_time_total`:** Estimated total wall clock time for the simulation.
+* **`wall_time_remaining`:** Estimated remaining wall clock time.
+* **`wall_time_spent`:** Total wall clock time already spent.
+* **`percent_complete`:** Percentage of the simulation completed.
+* **`estimated_sypd`:** Estimated simulated years per day (or days per day if
+  the rate is slow).
+* **`date_now`:** The current date and time.
+* **`estimated_finish_date`:** The estimated date and time of completion.
+
+!!! note
+
+    The estimated values (like `wall_time_remaining` and `estimated_sypd`) are
+    based on the average wall time per step and can fluctuate, especially early
+    in the simulation.  They become more reliable as the simulation progresses.
+
+## API
+
+```@docs
+ClimaUtilities.OnlineLogging.WallTimeInfo
+ClimaUtilities.OnlineLogging.report_walltime
+```

--- a/src/ClimaUtilities.jl
+++ b/src/ClimaUtilities.jl
@@ -12,6 +12,7 @@ include("TimeVaryingInputs.jl")
 
 include("ClimaArtifacts.jl")
 
+include("OnlineLogging.jl")
 include("OutputPathGenerator.jl")
 
 end # module ClimaUtilities

--- a/src/OnlineLogging.jl
+++ b/src/OnlineLogging.jl
@@ -1,0 +1,200 @@
+module OnlineLogging
+
+import Dates
+
+"""
+    WallTimeInfo
+
+Hold information about wall time.
+"""
+struct WallTimeInfo
+    """How many times the `update!` function has been called on this object. `update!` is
+    intended to be call at the end of every timestep with a callback. This field is
+    primarily used to exclude compilation from the timings."""
+    n_calls::Base.RefValue{Int}
+
+    """Wall time of the previous call to update `WallTimeInfo`."""
+    t_wall_last::Base.RefValue{Float64}
+
+    # We don't save t_wall_init, but ∑Δt_wall because we want to avoid including the
+    # compilation time in here. update_progress_reporter! will skip the first couple of
+    # steps
+    """Sum of elapsed walltime all the calls to `_update!`"""
+    ∑Δt_wall::Base.RefValue{Float64}
+    function WallTimeInfo()
+        n_calls = Ref(0)
+        t_wall_last = Ref(-1.0)
+        ∑Δt_wall = Ref(0.0)
+        return new(n_calls, t_wall_last, ∑Δt_wall)
+    end
+end
+
+"""
+    _update!(wt::WallTimeInfo)
+
+Update the timing information stored in the `WallTimeInfo` struct `wt`.
+
+This function tracks the wall time elapsed since the last call to `update!`. It handles the
+initial calls specially to exclude compilation time from the overall timing measurements.
+"""
+function _update!(wt::WallTimeInfo)
+    # - The very first call (when `n_calls == 0`), there's no elapsed times to report (and
+    #   this is called during initialization, before `step!` has been called).
+    # - The second call (`n_calls == 1`) is after `step!` is called for the first time, but
+    #   we don't want to include this since it includes compilation time.
+    # - In the third call (`n_calls == 2`), we account for 2Δt_wall to compensate for the first
+    #   call that we didn't include (to exclude compilation time).
+    # - All the other calls are included without any special operation.
+
+    if wt.n_calls[] == 0 || wt.n_calls[] == 1
+        Δt_wall = 0.0
+    else
+        # How much walltime elapsed since list time we called `update!`?
+        Δt_wall = time() - wt.t_wall_last[]
+
+        # If this is our third call, we need to compensate for the one call we didn't
+        # include to exclude compilation time
+        wt.n_calls[] == 2 && (Δt_wall = 2Δt_wall)
+    end
+
+    wt.n_calls[] += 1
+    wt.t_wall_last[] = time()
+    wt.∑Δt_wall[] += Δt_wall
+    return nothing
+end
+
+"""
+    report_walltime(wt::WallTimeInfo, integrator)
+
+Report the current progress and estimated completion time of a simulation.
+
+This function calculates and displays various timing statistics based on the provided
+`WallTimeInfo` (`wt`) and the `integrator` state. It estimates the remaining wall time,
+total simulation time, and simulated time per real-time unit.
+
+Prints a summary of the simulation progress to the console, including:
+
+- `simulation_time`: The current simulated time.
+- `n_steps_completed`: The number of completed steps.
+- `wall_time_per_step`: Average wall time per simulation step. You should expect this to be
+                        unreliable until the number of completed steps is large.
+- `wall_time_total`: Estimated total wall time for the simulation. You should expect this to be
+                     unreliable until the number of completed steps is large.
+- `wall_time_remaining`: Estimated remaining wall time. You should expect this to be
+                         unreliable until the number of completed steps is large.
+- `wall_time_spent`: Total wall time spent so far.
+- `percent_complete`: Percentage of the simulation completed.
+- `estimated_sypd`: Estimated simulated years per day (or simulated days per day if sypd is
+                    very small). You should expect this to be unreliable until the number of
+                    completed steps is large.
+- `date_now`: The current date and time.
+- `estimated_finish_date`: The estimated date and time of simulation completion. You should
+                           expect this to be unreliable until the number of completed steps
+                           is large.
+
+!!! note
+
+    Average quantities and simulated-years-per-day are computed by taking the total time
+    elapsed (minus initial compilation) and dividing by the number of steps completed. You
+    should expect them to fluctuate heavily and to be unreliable until the number of steps
+    become large. "Large" is defined by your problem: for example, the code has to go
+    through all the callbacks and diagnostics a few times before stabilizing (and this is
+    different for different simulations).
+
+## Arguments:
+
+* `wt::WallTimeInfo`:  A struct containing wall time information.
+* `integrator`: The integrator object containing simulation state information, including the
+                 current time `t`, timestep `dt`. It also have to have time span `tspan`
+                 in `integrator.sol.prob.tspan`.
+
+## How to use `report_walltime`
+
+`report_walltime` is intended to be used as a callback executed at the end of a simulation
+step. The callback can be called with an arbitrary schedule, so that reporting can be
+customized.
+
+### Example
+
+Suppose we want to report progress every 10 steps in a `SciMLBase`-type of integrator.
+```julia
+import ClimaUtilities.OnlineLogging: WallTimeInfo, report_progress
+import SciMLBase
+
+# Prepare the WallTimeInfo
+walltime_info = WallTimeInfo()
+
+# Define schedule, a boolean function that takes the integrator
+every10steps(u, t, integrator) = mod(integrator.step, 10) == 0
+
+# Define the callback, we use `let` to make this a little faster
+report = let wt = walltime_info
+     (integrator) -> report_progress(wt, integrator)
+end
+report_callback = SciMLBase.DiscreteCallback(every10steps, report)
+
+# Then, we can attach this callback to the integrator
+```
+TODO: Discuss/link `Schedules` when we move them to `ClimaUtilities`.
+"""
+function report_walltime(wt, integrator)
+    _update!(wt)
+
+    t_start, t_end = integrator.sol.prob.tspan
+    dt = integrator.dt
+    t = integrator.t
+
+    n_steps_total = ceil(Int, (t_end - t_start) / dt)
+    n_steps = ceil(Int, (t - t_start) / dt)
+
+    wall_time_ave_per_step = wt.∑Δt_wall[] / n_steps
+    wall_time_ave_per_step_str = _time_and_units_str(wall_time_ave_per_step)
+    percent_complete = round((t - t_start) / t_end * 100; digits = 1)
+    n_steps_remaining = n_steps_total - n_steps
+    wall_time_remaining = wall_time_ave_per_step * n_steps_remaining
+    wall_time_remaining_str = _time_and_units_str(wall_time_remaining)
+    wall_time_total =
+        _time_and_units_str(wall_time_ave_per_step * n_steps_total)
+    wall_time_spent = _time_and_units_str(wt.∑Δt_wall[])
+    simulation_time = _time_and_units_str(Float64(t))
+
+    simulated_seconds_per_second = (t - t_start) / wt.∑Δt_wall[]
+    simulated_seconds_per_day = simulated_seconds_per_second * 86400
+    simulated_days_per_day = simulated_seconds_per_day / 86400
+    simulated_years_per_day = simulated_days_per_day / 365.25
+
+    sypd_estimate = string(round(simulated_years_per_day; digits = 3))
+    # When simulated_years_per_day is too small, also report the simulated_days_per_day
+    if simulated_years_per_day < 0.01
+        sdpd_estimate = round(simulated_days_per_day, digits = 3)
+        sypd_estimate *= " (sdpd_estimate = $sdpd_estimate)"
+    end
+
+    estimated_finish_date =
+        Dates.now() + Dates.Second(ceil(wall_time_remaining))
+
+    @info "Progress" simulation_time = simulation_time n_steps_completed =
+        n_steps wall_time_per_step = wall_time_ave_per_step_str wall_time_total =
+        wall_time_total wall_time_remaining = wall_time_remaining_str wall_time_spent =
+        wall_time_spent percent_complete = "$percent_complete%" estimated_sypd =
+        sypd_estimate date_now = Dates.now() estimated_finish_date =
+        estimated_finish_date
+
+    return nothing
+end
+
+# TODO: Consider moving this to TimeManager
+"""
+    _time_and_units_str(seconds::Real)
+
+Returns a truncated string of time and units, given a time `x` in Seconds.
+"""
+function _time_and_units_str(seconds)
+    isapprox(seconds, 0) && return "0 seconds"
+    nanoseconds = Dates.Nanosecond(ceil(1_000_000_000seconds))
+    compound_period = Dates.canonicalize(Dates.CompoundPeriod(nanoseconds))
+    return _trunc_time(string(compound_period))
+end
+_trunc_time(s::String) = count(',', s) > 1 ? join(split(s, ",")[1:2], ",") : s
+
+end

--- a/src/OutputPathGenerator.jl
+++ b/src/OutputPathGenerator.jl
@@ -137,6 +137,8 @@ function generate_output_path(
     style::OutputPathGeneratorStyle = ActiveLinkStyle(),
 )
     output_path == "" && error("output_path cannot be empty")
+    # Let's make sure we are synced before we do any filesystem operation
+    ClimaComms.barrier(context)
     return generate_output_path(style, output_path; context)
 end
 

--- a/test/onlinelogging.jl
+++ b/test/onlinelogging.jl
@@ -1,0 +1,113 @@
+using Test
+import Logging
+import ClimaUtilities.OnlineLogging:
+    WallTimeInfo, _update!, report_walltime, _time_and_units_str, _trunc_time
+
+@testset "OnlineLogging Tests" begin
+    # Mock integrator struct for testing
+    Base.@kwdef struct MockIntegrator
+        sol::Any
+        dt::Any
+        t::Any
+        step::Any
+    end
+
+    @testset "WallTimeInfo" begin
+        wt = WallTimeInfo()
+        @test wt.n_calls[] == 0
+        @test wt.t_wall_last[] == -1.0
+        @test wt.∑Δt_wall[] == 0.0
+    end
+
+    @testset "_update!" begin
+        wt = WallTimeInfo()
+
+        # First call
+        _update!(wt)
+        @test wt.n_calls[] == 1
+        @test wt.∑Δt_wall[] == 0.0
+
+        # Second call
+        _update!(wt)
+        @test wt.n_calls[] == 2
+        @test wt.∑Δt_wall[] == 0.0
+
+        # Third call (compilation time compensation)
+        t1 = time()
+        sleep(0.1) # Introduce a small delay to simulate elapsed time
+        _update!(wt)
+        t2 = time()
+        @test wt.n_calls[] == 3
+        @test wt.∑Δt_wall[] ≈ 2 * (t2 - t1) atol = 0.1
+
+        # Fourth call (normal update)
+        t1 = time()
+        sleep(0.1)
+        _update!(wt)
+        t2 = time()
+
+        @test wt.n_calls[] == 4
+        @test isapprox(wt.∑Δt_wall[], 2 * (time() - t1) + (t2 - t1), atol = 0.1)
+
+    end
+
+    @testset "report_walltime" begin
+        wt = WallTimeInfo()
+        integrator = MockIntegrator(;
+            sol = (; prob = (; tspan = (0.0, 10.0))),
+            dt = 0.1,
+            t = 2.0,
+            step = 20,
+        )
+
+        io = IOBuffer()
+        Logging.with_logger(Logging.SimpleLogger(io)) do
+            report_walltime(wt, integrator)
+        end
+        output_string = String(take!(io))
+
+        # Check that the expected information is present in the output
+        @test occursin("Progress", output_string)
+        @test occursin("simulation_time", output_string)
+        @test occursin("n_steps_completed = 20", output_string) # Check for correct step count
+
+        # Reset WallTimeInfo and introduce delays to ensure non-zero times:
+        wt = WallTimeInfo()
+        _update!(wt)
+        sleep(0.1)
+        _update!(wt)
+        sleep(0.1)
+        _update!(wt)  # This call should now trigger non-zero times in report_walltime
+
+        io = IOBuffer()
+        Logging.with_logger(Logging.SimpleLogger(io)) do
+            report_walltime(wt, integrator)
+        end
+        output_string = String(take!(io))
+
+        # Check if timings are reported now that they're non-zero
+        @test occursin("wall_time_per_step", output_string)
+        @test occursin("wall_time_total", output_string)
+        @test occursin("wall_time_remaining", output_string)
+        @test occursin("wall_time_spent", output_string)
+        @test occursin("percent_complete", output_string)
+
+        @test occursin("estimated_sypd", output_string)
+        @test occursin("date_now", output_string)
+        @test occursin("estimated_finish_date", output_string)
+    end
+
+    @testset "_time_and_units_str" begin
+        @test _time_and_units_str(0.0) == "0 seconds"
+        @test _time_and_units_str(1.0) == "1 second"
+        @test _time_and_units_str(60.0) == "1 minute"
+        @test _time_and_units_str(3600.0) == "1 hour"
+        @test _time_and_units_str(3661.0) == "1 hour, 1 minute" # Test truncation
+    end
+
+    @testset "_trunc_time" begin
+        @test _trunc_time("1 hour, 1 minute, 1 second") == "1 hour, 1 minute"
+        @test _trunc_time("1 minute, 1 second") == "1 minute, 1 second"
+        @test _trunc_time("1 second") == "1 second"
+    end
+end


### PR DESCRIPTION
`OnlineLogging` is a new module (mostly based on ClimaAtmos `WallTimeEstimate`) that contains tools to provide informative messages while a simulation is running.

At the moment, `OnlineLogging` only contains `WallTimeInfo`, to report on timing information.

This new module will allow ClimaLand and ClimaCoupler to add some progress information, and remove some entries from the atmos cache.
