### PR TITLE
Improve error message for undownloadable artifacts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -73,10 +73,13 @@ The default cache size for regridded fields in `DataHandler` was reduced from
 128 to 2, reducing the memory footprint. You can pass the `cache_max_size`
 keyword argument to control this value.
 
-#### Error hints
+#### Improved error handling
 
-When using a function that depends on loading another package, the error now tells the user
-which package should be loaded if the package has not been loaded already.
+When using a function that depends on loading another package, the error now
+tells the user which package should be loaded if the package has not been loaded
+already. Furthermore, if there is an error with `@clima_artifact`, the error
+message tells the user that the artifact might be undownloadable and recommends
+downloading it themselves.
 
 v0.1.19
 ------


### PR DESCRIPTION
closes #106 - This PR adds a message to the already existing error message that the artifact may be undownloadable and suggests to manually download the artifact and adds the artifact to Overrides.toml if this is the case. We do *not* check if the artifact is undownloadable.

The error message now look like this even if the artifact is downloadable for whatever reason:
```julia
ERROR: Artifact "era5_monthly_averages_pressure_levels_1979_2024" was not found by looking in the paths:
  ~/.julia/artifacts/dd7ee9500805f590f8fc4c00bfc373eeb7a01587
  ~/.julia/juliaup/julia-1.11.2+0.x64.linux.gnu/local/share/julia/artifacts/dd7ee9500805f590f8fc4c00bfc373eeb7a01587
  ~/.julia/juliaup/julia-1.11.2+0.x64.linux.gnu/share/julia/artifacts/dd7ee9500805f590f8fc4c00bfc373eeb7a01587
Try `using Pkg; Pkg.instantiate()` to re-install all missing resources if the artifact is part of a package or call `Pkg.ensure_artifact_installed` (https://pkgdocs.julialang.org/v1/api/#Pkg.Artifacts.ensure_artifact_installed) if not.
The artifact may also be too large to download. If this is the case, download the files directly and indicate where the file lives in Overrides.toml (see ClimaArtifacts documentation for how to do this).
```