### PR TITLE
Changes the internal behavior of TimeVaryingInputs23D to use dates rather than seconds since start date

### DIFF
--- a/docs/src/datahandling.md
+++ b/docs/src/datahandling.md
@@ -189,6 +189,8 @@ ClimaUtilities.DataHandling.available_times
 ClimaUtilities.DataHandling.available_dates
 ClimaUtilities.DataHandling.previous_time
 ClimaUtilities.DataHandling.next_time
+ClimaUtilities.DataHandling.previous_date
+ClimaUtilities.DataHandling.next_date
 ClimaUtilities.DataHandling.regridded_snapshot
 ClimaUtilities.DataHandling.regridded_snapshot!
 ClimaUtilities.DataHandling.dt

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -512,6 +512,46 @@ function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
 end
 
 """
+    DataHandling.previous_date(data_handler::DataHandler, time::Dates.TimeType)
+
+Return the date of the snapshot before the given `date`.
+If `date` is one of the snapshots, return itself.
+
+If `date` is not in the `data_handler`, return an error.
+"""
+function DataHandling.previous_date(
+    data_handler::DataHandler,
+    date::Dates.TimeType,
+)
+    if date in data_handler.available_dates
+        index = searchsortedfirst(data_handler.available_dates, date)
+    else
+        index = searchsortedfirst(data_handler.available_dates, date) - 1
+    end
+    index < 1 && error("Date $date is before available dates")
+    return data_handler.available_dates[index]
+end
+
+"""
+    DataHandling.next_date(data_handler::DataHandler, time::Dates.TimeType)
+
+Return the date of the snapshot after the given `time`.
+If `date` is one of the snapshots, return itself.
+
+If `date` is not in the `data_handler`, return an error.
+"""
+function DataHandling.next_date(data_handler::DataHandler, date::Dates.TimeType)
+    if date in data_handler.available_dates
+        index = searchsortedfirst(data_handler.available_dates, date) + 1
+    else
+        index = searchsortedfirst(data_handler.available_dates, date)
+    end
+    index > length(data_handler.available_dates) &&
+        error("Date $date is after available dates")
+    return data_handler.available_dates[index]
+end
+
+"""
     regridded_snapshot(data_handler::DataHandler, date::Dates.DateTime)
     regridded_snapshot(data_handler::DataHandler, time::AbstractFloat)
     regridded_snapshot(data_handler::DataHandler)

--- a/src/DataHandling.jl
+++ b/src/DataHandling.jl
@@ -51,6 +51,10 @@ function previous_time end
 
 function next_time end
 
+function previous_date end
+
+function next_date end
+
 function regridded_snapshot end
 
 function regridded_snapshot! end
@@ -68,6 +72,8 @@ extension_fns = [
         :available_dates,
         :previous_time,
         :next_time,
+        :previous_date,
+        :next_date,
         :regridded_snapshot,
         :regridded_snapshot!,
         :dt,
@@ -80,6 +86,8 @@ extension_fns = [
         :available_dates,
         :previous_time,
         :next_time,
+        :previous_date,
+        :next_date,
         :regridded_snapshot,
         :regridded_snapshot!,
         :dt,

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -361,6 +361,31 @@ end
                     available_dates[10],
                 ) == available_times[10]
 
+                # Previous date
+                @test_throws ErrorException DataHandling.previous_date(
+                    data_handler,
+                    available_dates[1] - Second(1),
+                )
+
+                @test DataHandling.previous_date(
+                    data_handler,
+                    available_dates[10] + Second(1),
+                ) == available_dates[10]
+                @test DataHandling.previous_date(
+                    data_handler,
+                    available_dates[1] + Second(1),
+                ) == available_dates[1]
+
+                # Previous time with time, boundaries (return the node)
+                @test DataHandling.previous_date(
+                    data_handler,
+                    available_dates[1],
+                ) == available_dates[1]
+                @test DataHandling.previous_date(
+                    data_handler,
+                    available_dates[end],
+                ) == available_dates[end]
+
                 # Next time with time
                 @test_throws ErrorException DataHandling.next_time(
                     data_handler,
@@ -390,6 +415,31 @@ end
                     data_handler,
                     available_dates[10],
                 ) == available_times[11]
+
+                # Next date
+                @test_throws ErrorException DataHandling.next_date(
+                    data_handler,
+                    available_dates[end] + Second(1),
+                )
+
+                @test DataHandling.next_date(
+                    data_handler,
+                    available_dates[10] + Second(1),
+                ) == available_dates[11]
+                @test DataHandling.next_date(
+                    data_handler,
+                    available_dates[1] + Second(1),
+                ) == available_dates[2]
+
+                # On node
+                @test DataHandling.next_date(
+                    data_handler,
+                    available_dates[10],
+                ) == available_dates[11]
+                @test DataHandling.next_date(
+                    data_handler,
+                    available_dates[10],
+                ) == available_dates[11]
 
                 # Asking for a regridded_snapshot without specifying the time
                 @test_throws ErrorException DataHandling.regridded_snapshot(

--- a/test/time_varying_inputs23.jl
+++ b/test/time_varying_inputs23.jl
@@ -142,170 +142,199 @@ include("TestTools.jl")
                             ),
                         ),
                     )
-
                 @test 0.0 in input_nearest
-                @test !(1e23 in input_nearest)
+                @test !(82801.0 in input_nearest)
+                @test Dates.DateTime(2021, 1, 1, 0) in input_nearest
+                @test !(Dates.DateTime(2021, 1, 2, 0) in input_nearest)
 
                 available_times = DataHandling.available_times(data_handler)
+                available_dates = DataHandling.available_dates(data_handler)
                 dest = Fields.zeros(target_space)
 
                 # Time outside of range
-                @test_throws ErrorException TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest,
-                    FT(-40000),
-                )
+                for t in (FT(-40000), Dates.DateTime(2020))
+                    @test_throws ErrorException TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest,
+                        t,
+                    )
+                end
 
                 # We are testing NearestNeighbor, so we can just have to check if the fields agree
 
                 # Left nearest point
                 target_time = available_times[10] + 1
-                TimeVaryingInputs.evaluate!(dest, input_nearest, target_time)
+                target_date = available_dates[10] + Second(1)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest,
+                        target_time,
+                    )
 
-                # We use isequal to handle NaNs
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[10],
+                    # We use isequal to handle NaNs
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[10],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # Right nearest point
                 target_time = available_times[9] - 1
-                TimeVaryingInputs.evaluate!(dest, input_nearest, target_time)
+                target_date = available_dates[9] - Second(1)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(dest, input_nearest, t)
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[9],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[9],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # On node
                 target_time = available_times[11]
-                TimeVaryingInputs.evaluate!(dest, input_nearest, target_time)
+                target_date = available_dates[11]
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest,
+                        target_time,
+                    )
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[11],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[11],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # Flat left
                 target_time = available_times[begin] - 1
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest_flat,
-                    target_time,
-                )
+                target_date = available_dates[begin] - Second(1)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(dest, input_nearest_flat, t)
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[begin],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[begin],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # Flat right
                 target_time = available_times[end] + 1
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest_flat,
-                    target_time,
-                )
+                target_date = available_dates[end] + Second(1)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(dest, input_nearest_flat, t)
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[end],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[end],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # Nearest periodic calendar
                 dt = available_times[2] - available_times[1]
                 target_time = available_times[end] + 0.1dt
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest_periodic_calendar,
-                    target_time,
-                )
+                d_date = available_dates[2] - available_dates[1]
+                target_date = available_dates[end] + 0.1d_date
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest_periodic_calendar,
+                        target_time,
+                    )
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[end],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[end],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # With date
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest_periodic_calendar_date,
-                    target_time,
-                )
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest_periodic_calendar_date,
+                        target_time,
+                    )
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[end],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[end],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 dt = available_times[2] - available_times[1]
                 target_time = available_times[end] + 0.6dt
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_nearest_periodic_calendar,
-                    target_time,
-                )
+                d_date = available_dates[2] - available_dates[1]
+                target_date = available_dates[end] + 0.6d_date
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_nearest_periodic_calendar,
+                        target_time,
+                    )
 
-                @test isequal(
-                    Array(parent(dest)),
-                    Array(
-                        parent(
-                            DataHandling.regridded_snapshot(
-                                data_handler,
-                                available_times[begin],
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[begin],
+                                ),
                             ),
                         ),
-                    ),
-                )
+                    )
+                end
 
                 # Now testing LinearInterpolation
                 input_linear = TimeVaryingInputs.TimeVaryingInput(data_handler)
@@ -315,6 +344,11 @@ include("TestTools.jl")
                     dest,
                     input_linear,
                     FT(-40000),
+                )
+                @test_throws ErrorException TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_linear,
+                    Dates.DateTime(2021, 1, 1) + Second(-40000),
                 )
 
                 left_value = DataHandling.regridded_snapshot(
@@ -330,7 +364,7 @@ include("TestTools.jl")
                 left_time = available_times[10]
                 right_time = available_times[11]
 
-                TimeVaryingInputs.evaluate!(dest, input_linear, target_time)
+                target_date = available_dates[10] + Second(30)
 
                 expected = Fields.zeros(target_space)
                 expected .=
@@ -338,7 +372,10 @@ include("TestTools.jl")
                     (target_time - left_time) / (right_time - left_time) .*
                     (right_value .- left_value)
 
-                @test parent(dest) ≈ parent(expected)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(dest, input_linear, t)
+                    @test parent(dest) ≈ parent(expected)
+                end
 
                 # LinearInterpolation with PeriodicCalendar
                 time_delta = 0.1dt
@@ -358,26 +395,32 @@ include("TestTools.jl")
                 left_time = available_times[10]
                 right_time = available_times[11]
 
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_linear_periodic_calendar,
-                    target_time,
-                )
-
                 expected = Fields.zeros(target_space)
                 expected .=
                     left_value .+ time_delta / dt .* (right_value .- left_value)
 
-                @test parent(dest) ≈ parent(expected)
+                target_date = available_dates[end] + 0.1d_date
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_linear_periodic_calendar,
+                        target_time,
+                    )
+                    @test parent(dest) ≈ parent(expected)
+                end
 
                 # With offset of one period
-                TimeVaryingInputs.evaluate!(
-                    dest,
-                    input_linear_periodic_calendar_date,
-                    target_time + 86400,
-                )
+                target_time += 86400
+                target_date += Second(86400)
+                for t in (target_time, target_date)
+                    TimeVaryingInputs.evaluate!(
+                        dest,
+                        input_linear_periodic_calendar_date,
+                        t,
+                    )
 
-                @test parent(dest) ≈ parent(expected)
+                    @test parent(dest) ≈ parent(expected)
+                end
 
                 close(input_multiple_vars)
                 close(input_nearest)

--- a/test/utils.jl
+++ b/test/utils.jl
@@ -55,6 +55,18 @@ end
     # Wrapping when time equals t_init or t_end
     @test wrap_time(10, t_init, t_end) == 10
     @test wrap_time(20, t_init, t_end) == 10
+
+    date_init = Dates.DateTime(2010) + Dates.Second(10)
+    date_end = Dates.DateTime(2010) + Dates.Second(20)
+    dt = Dates.Second(1)
+
+    @test wrap_time(date_init + 5dt, date_init, date_end) == date_init + 5dt
+    @test wrap_time(date_end + 5dt, date_init, date_end) == date_init + 5dt
+    @test wrap_time(date_init - 5dt, date_init, date_end) == date_init + 5dt
+
+    # Wrapping when time equals date_init or date_end
+    @test wrap_time(date_init, date_init, date_end) == date_init
+    @test wrap_time(date_end, date_init, date_end) == date_init
 end
 
 @testset "bounding_dates" begin


### PR DESCRIPTION
closes #146 - This commit changes the internal behavior of TimeVaryingInputs23D to use dates rather than seconds since start date. This will make the transition to ITime a little easier since it is easy to convert a ITime to a date.

The behavior of TimeVaryingInputs23D will only differ when `dt` in milliseconds is an odd number or precision more than one millisecond is required. For the first case, this is because the code computes `dt / 2` in `_time_range_dt_dt_e`. In all other cases, the behavior should be identical as before.