### PR TITLE
Remove specialization from TVI

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>"]
-version = "0.1.23"
+authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
+version = "0.1.24"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -151,9 +151,9 @@ function TimeVaryingInputs.TimeVaryingInput(
 end
 
 function TimeVaryingInputs.TimeVaryingInput(
-    file_paths::Union{AbstractString, AbstractArray{<:AbstractString}},
-    varnames::Union{AbstractString, AbstractArray{<:AbstractString}},
-    target_space::ClimaCore.Spaces.AbstractSpace;
+    file_paths,
+    varnames,
+    target_space;
     method = LinearInterpolation(),
     start_date::Union{Dates.DateTime, Dates.Date} = Dates.DateTime(1979, 1, 1),
     regridder_type = nothing,


### PR DESCRIPTION
`TimeVaryingInputs.TimeVaryingInput` was restricting the arguments that could be passed down to `DataHandler`. In particular, it was not possible to pass vectors of vectors, even if that's something that the `DataHandler` supports.
