### PR TITLE
Add regrid! to InterpolationsRegridder

### DIFF
--- a/src/Regridders.jl
+++ b/src/Regridders.jl
@@ -23,6 +23,8 @@ function InterpolationsRegridder end
 
 function regrid end
 
+function regrid! end
+
 """
     default_regridder_type()
 

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -129,6 +129,13 @@ end
     @test regridded_lat_reversed == regridded_lat
     @test regridded_lon_reversed == regridded_lon
     @test regridded_z_reversed == regridded_z
+
+    @test_throws "Dimensions must be monotonically increasing to use regrid!. Sort the dimensions first, or use regrid." Regridders.regrid!(
+        zeros(axes(regridded_z_reversed)),
+        reg_hv_reversed,
+        data_lat3D,
+        dimensions3D_reversed,
+    )
 end
 
 @testset "InterpolationsRegridder" begin
@@ -177,6 +184,25 @@ end
         regridded_lat = Regridders.regrid(reg_horz, data_lat2D, dimensions2D)
         regridded_lon = Regridders.regrid(reg_horz, data_lon2D, dimensions2D)
 
+        # now repeat the regrid with in place method, and check that the result is the same
+        in_place_regridded_lat = zeros(axes(regridded_lat))
+        in_place_regridded_lon = zeros(axes(regridded_lon))
+        Regridders.regrid!(
+            in_place_regridded_lat,
+            reg_horz,
+            FT.(data_lat2D),
+            map(x -> FT.(x), dimensions2D),
+        )
+        Regridders.regrid!(
+            in_place_regridded_lon,
+            reg_horz,
+            FT.(data_lon2D),
+            map(x -> FT.(x), dimensions2D),
+        )
+
+        @test regridded_lat == in_place_regridded_lat
+        @test regridded_lon == in_place_regridded_lon
+
         coordinates = ClimaCore.Fields.coordinate_field(horzspace)
 
         # Compute max err
@@ -201,6 +227,32 @@ end
         regridded_lat = Regridders.regrid(reg_hv, data_lat3D, dimensions3D)
         regridded_lon = Regridders.regrid(reg_hv, data_lon3D, dimensions3D)
         regridded_z = Regridders.regrid(reg_hv, data_z3D, dimensions3D)
+
+        in_place_regridded_lat = zeros(axes(regridded_lat))
+        in_place_regridded_lon = zeros(axes(regridded_lon))
+        in_place_regridded_z = zeros(axes(regridded_z))
+        Regridders.regrid!(
+            in_place_regridded_lat,
+            reg_hv,
+            FT.(data_lat3D),
+            map(x -> FT.(x), dimensions3D),
+        )
+        Regridders.regrid!(
+            in_place_regridded_lon,
+            reg_hv,
+            FT.(data_lon3D),
+            map(x -> FT.(x), dimensions3D),
+        )
+        Regridders.regrid!(
+            in_place_regridded_z,
+            reg_hv,
+            FT.(data_z3D),
+            map(x -> FT.(x), dimensions3D),
+        )
+
+        @test regridded_lat == in_place_regridded_lat
+        @test regridded_lon == in_place_regridded_lon
+        @test regridded_z == in_place_regridded_z
 
         coordinates = ClimaCore.Fields.coordinate_field(hv_center_space)
 
@@ -249,6 +301,33 @@ end
     regridded_y = Regridders.regrid(reg_box, data_y3D, dimensions3D)
 
     regridded_z = Regridders.regrid(reg_box, data_z3D, dimensions3D)
+    # repeat the regrid with in place method, and check that the result is the same
+    regridded_x_inplace = zeros(axes(regridded_x))
+    regridded_y_inplace = zeros(axes(regridded_y))
+    regridded_z_inplace = zeros(axes(regridded_z))
+
+    Regridders.regrid!(
+        regridded_x_inplace,
+        reg_box,
+        FT.(data_x3D),
+        map(x -> FT.(x), dimensions3D),
+    )
+    Regridders.regrid!(
+        regridded_y_inplace,
+        reg_box,
+        FT.(data_y3D),
+        map(x -> FT.(x), dimensions3D),
+    )
+    Regridders.regrid!(
+        regridded_z_inplace,
+        reg_box,
+        FT.(data_z3D),
+        map(x -> FT.(x), dimensions3D),
+    )
+
+    @test regridded_x == regridded_x_inplace
+    @test regridded_y == regridded_y_inplace
+    @test regridded_z == regridded_z_inplace
 
     err_x = reg_box.coordinates.x .- regridded_x
     err_y = reg_box.coordinates.y .- regridded_y


### PR DESCRIPTION
regrid! stores the regridded data in a pre
allocated ClimaCore field. It also uses
interpolate! instead of interpolate. This still
allocates, but much less. It also may
modify the data passed in, but it does not
seem like that happens when using gridded
interpolation. The function also
requires that the base element type of
the passed in dimensions, undertype of the target space, and eltype of the output field all be the same

<!--- THESE LINES ARE COMMENTED -->
## Purpose 

Closes #156 


## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->

```
infil> @benchmark Regridders.regrid($reg_horz, $data_lon2D, $dimensions2D)
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  104.167 μs …  10.438 ms  ┊ GC (min … max): 0.00% … 98.75%
 Time  (median):     122.667 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   135.574 μs ± 248.607 μs  ┊ GC (mean ± σ):  9.17% ±  5.12%

                            ▃▇██▆▄▁                              
  ▁▁▁▁▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▇███████▇▅▄▃▂▂▂▂▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  104 μs           Histogram: frequency by time          142 μs <

 Memory estimate: 535.33 KiB, allocs estimate: 54.

infil> @benchmark Regridders.regrid!(
                          $in_place_regridded_lon,
                          $reg_horz,
                          $data_lon2D,
                          $dimensions2D,
                      )
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):   93.250 μs …   7.032 ms  ┊ GC (min … max): 0.00% … 98.17%
 Time  (median):     102.958 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   111.098 μs ± 203.899 μs  ┊ GC (mean ± σ):  6.82% ±  3.66%

                  ▁▃▅▆▇▇███▇▇▇▆▅▅▄▄▃▃▂▂▁▁▁▁                     ▃
  ▂▃▅▆███████▇▅▅▆▇████████████████████████████▇██▇▇█▇▆▆▆▆▅▆▆▆▆▆ █
  93.2 μs       Histogram: log(frequency) by time        117 μs <

 Memory estimate: 270.70 KiB, allocs estimate: 31.
```

### the `regrid!` that uses `interpolate!` instead of `interpolate`

```

infil> @benchmark Regridders.regrid!(
                   $in_place_regridded_lon,
                   $reg_horz,
                   $data_lon2D,
                   $dimensions2D,
               )
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  86.750 μs … 131.125 μs  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     88.125 μs               ┊ GC (median):    0.00%
 Time  (mean ± σ):   89.018 μs ±   2.614 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

     ▂█▆▃▂▄                                                     
  ▁▃▆███████▆▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▂▃▃▃▃▂▂▂▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁▁ ▂
  86.8 μs         Histogram: frequency by time         98.6 μs <

 Memory estimate: 15.41 KiB, allocs estimate: 29.
```

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
