### PR TITLE
Add deferopen = false when constructing multifile dataset

### DIFF
--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -581,7 +581,6 @@ function DataHandling.regridded_snapshot(
     end
 
     regridder_type = nameof(typeof(data_handler.regridder))
-    regrid_args = ()
 
     # Check if the regridded field at this date is already in the cache
     return get!(data_handler._cached_regridded_fields, date) do

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -107,7 +107,13 @@ function FileReaders.NCFileReader(
             is_time = x -> x == "time" || x == "date" || x == "t"
             time_dims = filter(is_time, NCDatasets.dimnames(first_dataset))
             if !isempty(time_dims)
-                aggtime_kwarg = (:aggdim => first(time_dims),)
+                # When loading multifile dataset using NCDatasets.jl, the NetCDF files are
+                # not kept open due to the common limitation of 1024 open files per user on
+                # Linux. However, for our use case, we will not reach this limit. Hence, we
+                # keep the files open with deferopen = false.
+                # See: https://github.com/JuliaGeo/NCDatasets.jl/issues/277
+                aggtime_kwarg =
+                    (:aggdim => first(time_dims), :deferopen => false)
             else
                 error(
                     "Multiple files given, but no temporal dimension found. Combining multiple files is only possible along the temporal dimension.",

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -237,7 +237,7 @@ function FileReaders.read(file_reader::NCFileReader, date::Dates.DateTime)
     if date == Dates.DateTime(0)
         return get!(file_reader._cached_reads, date) do
             file_reader.preprocess_func.(
-                Array(file_reader.dataset[file_reader.varname])
+                Array(file_reader.dataset[file_reader.varname]),
             )
         end
     end
@@ -253,7 +253,7 @@ function FileReaders.read(file_reader::NCFileReader, date::Dates.DateTime)
         i in 1:length(NCDatasets.dimnames(var))
     ]
     return file_reader.preprocess_func.(
-        file_reader.dataset[file_reader.varname][slicer...]
+        file_reader.dataset[file_reader.varname][slicer...],
     )
 end
 
@@ -278,7 +278,7 @@ function FileReaders.read(file_reader::NCFileReader)
     # When there's no dates, we use DateTime(0) as key
     return get!(file_reader._cached_reads, Dates.DateTime(0)) do
         return file_reader.preprocess_func.(
-            Array(file_reader.dataset[file_reader.varname])
+            Array(file_reader.dataset[file_reader.varname]),
         )
     end
 end

--- a/ext/nc_common.jl
+++ b/ext/nc_common.jl
@@ -11,7 +11,7 @@ or "date" datasets. If none is available, return an empty vector.
 function read_available_dates(ds::NetCDFDataset)
     if "time" in keys(ds.dim)
         return Dates.DateTime.(
-            reinterpret.(Ref(NCDatasets.DateTimeStandard), ds["time"][:])
+            reinterpret.(Ref(NCDatasets.DateTimeStandard), ds["time"][:]),
         )
     elseif "date" in keys(ds.dim)
         return Dates.DateTime.(string.(ds["date"][:]), Ref("yyyymmdd"))

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -45,10 +45,7 @@ using NCDatasets
 
         # Test that we need to close all the variables to close the file
         open_ncfiles =
-            Base.get_extension(
-                ClimaUtilities,
-                :ClimaUtilitiesNCDatasetsExt,
-            ).NCFileReaderExt.OPEN_NCFILES
+            Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
 
         close(ncreader_sp)
         @test !isempty(open_ncfiles)
@@ -75,10 +72,7 @@ end
     )
     NCDataset(PATH) do nc
         read_dates_func =
-            Base.get_extension(
-                ClimaUtilities,
-                :ClimaUtilitiesNCDatasetsExt,
-            ).NCFileReaderExt.read_available_dates
+            Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.read_available_dates
 
         available_dates = read_dates_func(nc)
         @test isempty(available_dates)
@@ -100,20 +94,14 @@ end
 
         FileReaders.close_all_ncfiles()
         open_ncfiles =
-            Base.get_extension(
-                ClimaUtilities,
-                :ClimaUtilitiesNCDatasetsExt,
-            ).NCFileReaderExt.OPEN_NCFILES
+            Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
         @test isempty(open_ncfiles)
     end
 end
 
 @testset "read_available_dates" begin
     read_dates_func =
-        Base.get_extension(
-            ClimaUtilities,
-            :ClimaUtilitiesNCDatasetsExt,
-        ).NCFileReaderExt.read_available_dates
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.read_available_dates
 
     data_dir = mktempdir()
     NCDataset(joinpath(data_dir, "test_time_1.nc"), "c") do nc

--- a/test/time_varying_inputs_linearperiodfilling.jl
+++ b/test/time_varying_inputs_linearperiodfilling.jl
@@ -22,16 +22,14 @@ include("TestTools.jl")
 @testset "InterpolatingTimeVaryingInput23D with LinearPeriodFillingInterpolation" begin
 
     # First, test the helper functions
-    _interpolable_range =
-        Base.get_extension(
-            ClimaUtilities,
-            :ClimaUtilitiesClimaCoreNCDatasetsExt,
-        ).TimeVaryingInputsExt._interpolable_range
-    _move_date_to_period =
-        Base.get_extension(
-            ClimaUtilities,
-            :ClimaUtilitiesClimaCoreNCDatasetsExt,
-        ).TimeVaryingInputsExt._move_date_to_period
+    _interpolable_range = Base.get_extension(
+        ClimaUtilities,
+        :ClimaUtilitiesClimaCoreNCDatasetsExt,
+    ).TimeVaryingInputsExt._interpolable_range
+    _move_date_to_period = Base.get_extension(
+        ClimaUtilities,
+        :ClimaUtilitiesClimaCoreNCDatasetsExt,
+    ).TimeVaryingInputsExt._move_date_to_period
 
     dates_period_left =
         [DateTime(1985, 1, 15), DateTime(1985, 2, 17), DateTime(1985, 12, 11)]


### PR DESCRIPTION
This PR adds `deferopen = false` when constructing a multifile dataset. According to this issue (https://github.com/JuliaGeo/NCDatasets.jl/issues/277), files are not kept open because of the limitation of 1024 open files on Linux. However, for our use case, this will not matter. 

See this [buildkite](https://buildkite.com/clima/climaland-long-runs/builds/3971#0196b1a7-1aae-4a0c-9df4-6ce556fdc33b) for a ClimaLand run for a single year with ~40 years of ERA5 forcing data without this change.
See this [buildkite](https://buildkite.com/clima/climaland-long-runs/builds/3987#0196cad7-4762-452d-b592-899dc75cc2f0) for a ClimaLand run for a single year with ~40 years of ERa5 forcing data with this change.
Also, see this [buildkite](https://buildkite.com/clima/climaland-long-runs/builds/3977#0196b251-76f1-4d94-95db-2e9aa179c48c) for a ClimaLand run for a single year with a single year of ERA5 forcing data.

The wall time per step for the three runs are

1. 35 milliseconds, 834 microseconds (forty years of ERA5 forcing data)
2. 25 milliseconds, 126 microseconds (forty years of ERA5 forcing data with this branch)
3. 22 milliseconds, 240 microseconds (single year of ERA5 forcing data)