### PR TITLE
Expose interpolation method to users

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,26 @@ ClimaUtilities.jl Release Notes
 main
 ------
 
+#### Interpolation method for InterpolationsRegridder
+
+`InterpolationsRegridder` now accepts the new keyword argument
+`interpolation_method` for choosing the mode of the gridded interpolation. The
+default is `Interpolations.Linear()`.
+
+```julia
+import ClimaUtilities.Regridders
+import ClimaCore, Interpolations
+
+linear_reg = Regridders.InterpolationsRegridder(
+    target_space,
+    interpolation_method = Intp.Linear(),
+)
+constant_reg = Regridders.InterpolationsRegridder(
+    target_space,
+    interpolation_method = Intp.Constant(),
+)
+```
+
 v0.1.23
 ------
 

--- a/docs/src/regridders.md
+++ b/docs/src/regridders.md
@@ -65,6 +65,13 @@ regridded_u = Regridders.regrid(reg, target_date)
 along each direction) and returns a `ClimaCore` `Field` defined on the
 `target_space`.
 
+!!! note "Did you know?"
+    With versions of ClimaUtilities after v0.1.24, you can choose the mode of
+    the gridded interpolation with the keyword argument `interpolation_method`.
+    For example, to do constant interpolation, you can pass
+    `interpolation_method = Interpolations.Constant()` as a keyword argument
+    when constructing the regridder.
+
 Currently, `InterpolationsRegridder` only supports spherical shells and extruded
 spherical shells (but it could be easily extended to other domains).
 

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -267,6 +267,40 @@ end
     end
 end
 
+@testset "Interpolation method" begin
+    # Test constant interpolation method
+    lon, lat, z =
+        collect(0.0:1:360), collect(-90.0:1:90), collect(0.0:1.0:100.0)
+    dimensions2D = (lon, lat)
+    dimensions3D = (lon, lat, z)
+    size2D = (361, 181)
+    size3D = (361, 181, 101)
+    ones_2Ddata = ones(size2D)
+    ones_3Ddata = ones(size3D)
+
+    for FT in (Float32, Float64)
+        spaces = make_spherical_space(FT; context)
+        horzspace = spaces.horizontal
+        hv_center_space = spaces.hybrid
+
+        reg_horz = Regridders.InterpolationsRegridder(
+            horzspace,
+            interpolation_method = Interpolations.Constant(),
+        )
+        reg_hv = Regridders.InterpolationsRegridder(
+            hv_center_space,
+            interpolation_method = Interpolations.Constant(),
+        )
+
+        regridded_2Ddata =
+            Regridders.regrid(reg_horz, ones_2Ddata, dimensions2D)
+        regridded_3Ddata = Regridders.regrid(reg_hv, ones_3Ddata, dimensions3D)
+
+        @test all(x -> x == one(x), parent(regridded_2Ddata))
+        @test all(x -> x == one(x), parent(regridded_3Ddata))
+    end
+end
+
 @testset "InterpolationsRegridderXYZPoint" begin
     helem = (10, 10)
     Nq = 4


### PR DESCRIPTION
This PR exposes the interpolation method to the users, so that they can change from `Intp.Linear()` to `Intp.Constant()` for example.

TODO

- [x] Update documentation
- [x] Make tests for interpolation method