### PR TITLE
Allow regridding 2D data onto 2D spaces with LatLongZ coordinates

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,12 @@ ClimaUtilities.jl Release Notes
 main
 ------
 
+#### Allow regridding 2D data onto 2D spaces with LatLongZ coordinates. PR[#176](https://github.com/CliMA/ClimaUtilities.jl/pull/176)
+
+Some 2D spaces use `LatLongPoint` coordinates and others use `LatLongZPoint`,
+depending on how they were constructed. Both cases are now supported, so we can
+read in 2D data onto a 2D space with either coordinate type.
+
 #### Interpolation method for InterpolationsRegridder
 
 `InterpolationsRegridder` now accepts the new keyword argument
@@ -29,9 +35,9 @@ v0.1.23
 
 #### Support for Box Interpolations Regridder. PR[#151](https://github.com/CliMA/ClimaUtilities.jl/pull/151)
 
-`Regridders.IterpolationsRegridder` now supports regridding on 
-`ClimaCore.Geometry.XYZPoint` objects which allows for interpolation 
-onto boxes and single column simulations. 
+`Regridders.IterpolationsRegridder` now supports regridding on
+`ClimaCore.Geometry.XYZPoint` objects which allows for interpolation
+onto boxes and single column simulations.
 
 v0.1.22
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
-version = "0.1.24"
+version = "0.1.25"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Previously, this would error because the interpolator would be constructed with dimensions corresponding to the 2D input data, but then try to regrid onto the 3D coordinates. The solution in this PR is to handle that case by displaying a warning and dropping the z dimension while interpolating.

Closes #174

## To-do
<!---  list of proposed tasks in the PR, move to "Content" on completion 
- Proposed task
-->


## Content
<!---  specific tasks that are currently complete 
- Solution implemented
-->


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [ ] I have read and checked the items on the review checklist.
