### PR TITLE
ITime housekeeping

### DIFF
--- a/src/ITime.jl
+++ b/src/ITime.jl
@@ -415,6 +415,8 @@ function Base.float(t::T) where {T <: ITime}
     end
 end
 
+(::Type{FT})(t::ITime) where {FT <: AbstractFloat} = FT(float(t))
+
 macro itime_unary_op(op)
     return esc(
         quote

--- a/test/itime.jl
+++ b/test/itime.jl
@@ -148,6 +148,8 @@ using Test, Dates
     @testset "Float Conversion and Broadcasting" begin
         t1 = ITime(10, period = Dates.Millisecond(100))
         @test float(t1) == 1.0
+        @test Float64(t1) === Float64(1)
+        @test Float32(t1) === Float32(1)
 
         # Test broadcasting (simple example)
         @test float.(t1) == 1.0

--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -5,6 +5,7 @@ using Artifacts
 import ClimaUtilities
 import ClimaUtilities: DataHandling
 import ClimaUtilities: TimeVaryingInputs
+using ClimaUtilities.TimeManager
 
 import ClimaCore: Domains, Geometry, Fields, Meshes, Topologies, Spaces
 import ClimaComms
@@ -109,183 +110,247 @@ end
         column_field = Fields.zeros(column_space)
         point_field = Fields.zeros(point_space)
 
-        times = collect(range(FT(0), FT(8π), 100))
-        vals = sin.(times)
-        dt = times[2] - times[1]
+        start_date = Dates.DateTime(2014)
+        times_ft = collect(FT(0):FT(0.5):FT(100))
+        vals = sin.(times_ft)
+        itime_no_epoch = [promote(ITime.(times_ft)...)...]
+        add_test_epoch = t -> promote(t, ITime(0; epoch = start_date))[1]
+        itime_with_epoch = [promote(add_test_epoch.(itime_no_epoch)...)...]
 
-        # Nearest neighbor interpolation
-        input = TimeVaryingInputs.TimeVaryingInput(
-            times,
-            vals;
-            method = TimeVaryingInputs.NearestNeighbor(),
+        # tuple where first element is vector used to create test TimeVaryingInputs
+        # second element converts floats into the desired test inputs
+        # third element converts the elements of the times vector to the desired test inputs
+        for (times, ft_to_input, time_to_input) in (
+            (times_ft, identity, identity), # FT TVI, inputs as FT
+            (times_ft, ITime, ITime), # FT TVI, inputs as ITime no date
+            (
+                times_ft,
+                t -> add_test_epoch(ITime(t)),
+                t -> add_test_epoch(ITime(t)),
+            ), # FT TVI, inputs as ITime with date
+            (itime_no_epoch, ITime, identity), # ITime TVI no dates, inputs as ITime (no dates)
+            (itime_no_epoch, identity, float), # ITime TVI no dates, inputs as floats
+            (itime_no_epoch, t -> add_test_epoch(ITime(t)), add_test_epoch), # ITime TVI no dates, inputs as ITime with dates
+            (itime_with_epoch, t -> add_test_epoch(ITime(t)), identity), # ITime TVI with dates, inputs as ITime with dates
+            (
+                itime_with_epoch,
+                t -> ITime(t),
+                t -> ITime(t.counter; period = t.period),
+            ), # ITime TVI with dates, inputs as ITime with no dates
+            (itime_with_epoch, identity, float), # ITime TVI with dates, inputs as floats
+            (itime_with_epoch, t -> start_date + Second(t), DateTime), # ITime TVI with dates, inputs as datetimes
         )
+            dt = times[2] - times[1]
+            # Nearest neighbor interpolation
+            input = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.NearestNeighbor(),
+            )
 
-        # Nearest neighbor interpolation with Flat
-        input_clamp = TimeVaryingInputs.TimeVaryingInput(
-            times,
-            vals;
-            method = TimeVaryingInputs.NearestNeighbor(
-                TimeVaryingInputs.Flat(),
-            ),
-        )
+            # Nearest neighbor interpolation with Flat
+            input_clamp = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.NearestNeighbor(
+                    TimeVaryingInputs.Flat(),
+                ),
+            )
 
-        # Nearest neighbor interpolation with PeriodicCalendar
-        input_periodic_calendar = TimeVaryingInputs.TimeVaryingInput(
-            times,
-            vals;
-            method = TimeVaryingInputs.NearestNeighbor(
-                TimeVaryingInputs.PeriodicCalendar(),
-            ),
-        )
+            # Nearest neighbor interpolation with PeriodicCalendar
+            input_periodic_calendar = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.NearestNeighbor(
+                    TimeVaryingInputs.PeriodicCalendar(),
+                ),
+            )
 
-        # Linear interpolation with PeriodicCalendar
-        input_periodic_calendar_linear = TimeVaryingInputs.TimeVaryingInput(
-            times,
-            vals;
-            method = TimeVaryingInputs.LinearInterpolation(
-                TimeVaryingInputs.PeriodicCalendar(),
-            ),
-        )
+            # Linear interpolation with PeriodicCalendar
+            input_periodic_calendar_linear = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.LinearInterpolation(
+                    TimeVaryingInputs.PeriodicCalendar(),
+                ),
+            )
 
-        # Test extrapolation_bc
-        @test TimeVaryingInputs.extrapolation_bc(
-            TimeVaryingInputs.NearestNeighbor(),
-        ) == TimeVaryingInputs.Throw()
+            # Test extrapolation_bc
+            @test TimeVaryingInputs.extrapolation_bc(
+                TimeVaryingInputs.NearestNeighbor(),
+            ) == TimeVaryingInputs.Throw()
 
-        # Test in
-        @test FT(3.0) in input
-        @test !(FT(-3.0) in input)
+            # Test in
+            if ft_to_input(FT(3.0)) isa eltype(times)
+                @test FT(3.0) in input
+                @test !(FT(-3.0) in input)
+            end
 
-        # Test with different types of spaces
-        for dest in (point_field, column_field)
-            # Time outside of range
+            # Test with different types of spaces
+            for dest in (point_field, column_field)
+                # Time outside of range
+                @test_throws ErrorException TimeVaryingInputs.evaluate!(
+                    dest,
+                    input,
+                    ft_to_input(FT(-4)),
+                )
+
+                # Time outside of range with Flat left
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_clamp,
+                    ft_to_input(FT(-4)),
+                )
+                @test Array(parent(dest))[1] == vals[begin]
+
+                # Time outside of range with Flat right
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_clamp,
+                    ft_to_input(FT(400)),
+                )
+                @test Array(parent(dest))[1] == vals[end]
+
+                # Time outside of range with PeriodicCalendar
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar,
+                    time_to_input(times[begin]),
+                )
+                @test Array(parent(dest))[1] == vals[begin]
+
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar,
+                    time_to_input(times[end]),
+                )
+                @test Array(parent(dest))[1] == vals[end]
+
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar,
+                    time_to_input(times[end] + 10dt),
+                )
+                @test Array(parent(dest))[1] == vals[begin + 9]
+
+                # Check after times[end] but before times[end] + 0.5dt, should lead be
+                # equivalent to times[end]
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar,
+                    time_to_input(times[end] + 0.3dt),
+                )
+                @test Array(parent(dest))[1] == vals[end]
+
+                # Check after times[end] and after times[end] + 0.5dt, should lead be equivalent
+                # to times[begin]
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar,
+                    time_to_input(times[end] + 0.8dt),
+                )
+                @test Array(parent(dest))[1] == vals[begin]
+
+                # Linear interpolation
+
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input,
+                    time_to_input(times[10]),
+                )
+
+                @test Array(parent(dest))[1] == vals[10]
+
+                # Linear interpolation
+                input = TimeVaryingInputs.TimeVaryingInput(times, vals)
+
+                TimeVaryingInputs.evaluate!(dest, input, ft_to_input(FT(10)))
+
+                if eltype(time) <: Number
+                    # searchsortedfirst only needs to work with floats, as TVI0d will
+                    # internally handle conversions
+                    index = searchsortedfirst(times, 0.1)
+                    @test times[index - 1] <= 0.1 <= times[index]
+                    expected =
+                        vals[index - 1] +
+                        (vals[index] - vals[index - 1]) /
+                        (times[index] - times[index - 1]) *
+                        (0.1 - times[index - 1])
+
+                    @test Array(parent(dest))[1] ≈ expected
+                end
+
+                # Check edge case
+                TimeVaryingInputs.evaluate!(dest, input, ft_to_input(FT(0.0)))
+
+                @test Array(parent(dest))[1] ≈ 0.0
+
+                # Linear interpolation with PeriodicCalendar
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[10]),
+                )
+                @test Array(parent(dest))[1] == vals[10]
+
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[1]),
+                )
+                @test Array(parent(dest))[1] == vals[1]
+
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[end]),
+                )
+                @test Array(parent(dest))[1] == vals[end]
+
+                # t_end + dt is equivalent to t_init
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[end] + dt),
+                )
+                @test Array(parent(dest))[1] ≈ vals[1]
+
+                # t_end + 2dt is equivalent to t_init + dt
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[end] + 2dt),
+                )
+                @test Array(parent(dest))[1] ≈ vals[2]
+
+                # In between t_end and t_init
+                expected =
+                    vals[end] +
+                    (vals[begin] - vals[end]) / FT(float(dt)) * FT(0.1float(dt))
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_periodic_calendar_linear,
+                    time_to_input(times[end] + 0.1dt),
+                )
+                eltype(time) <: Number &&
+                    @test Array(parent(dest))[1] ≈ expected
+            end
+        end
+
+        # test errors when using datetime with TVI of floats or ITime without epoch
+        for dest in (point_field, column_field),
+            times in (times_ft, itime_no_epoch)
+
+            input = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.NearestNeighbor(),
+            )
             @test_throws ErrorException TimeVaryingInputs.evaluate!(
                 dest,
                 input,
-                FT(-4),
+                start_date,
             )
-
-            # Time outside of range with Flat left
-            TimeVaryingInputs.evaluate!(dest, input_clamp, FT(-4))
-
-            @test Array(parent(dest))[1] == vals[begin]
-
-            # Time outside of range with Flat right
-            TimeVaryingInputs.evaluate!(dest, input_clamp, FT(40))
-
-            @test Array(parent(dest))[1] == vals[end]
-
-            # Time outside of range with PeriodicCalendar
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar,
-                times[begin],
-            )
-            @test Array(parent(dest))[1] == vals[begin]
-
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar,
-                times[end],
-            )
-            @test Array(parent(dest))[1] == vals[end]
-
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar,
-                times[end] + 10dt,
-            )
-            @test Array(parent(dest))[1] == vals[begin + 9]
-
-            # Check after times[end] but before times[end] + 0.5dt, should lead be
-            # equivalent to times[end]
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar,
-                times[end] + 0.3dt,
-            )
-            @test Array(parent(dest))[1] == vals[end]
-
-            # Check after times[end] and after times[end] + 0.5dt, should lead be equivalent
-            # to times[begin]
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar,
-                times[end] + 0.8dt,
-            )
-            @test Array(parent(dest))[1] == vals[begin]
-
-            # Linear interpolation
-
-            TimeVaryingInputs.evaluate!(dest, input, times[10])
-
-            @test Array(parent(dest))[1] == vals[10]
-
-            # Linear interpolation
-            input = TimeVaryingInputs.TimeVaryingInput(times, vals)
-
-            TimeVaryingInputs.evaluate!(dest, input, 0.1)
-
-            index = searchsortedfirst(times, 0.1)
-            @test times[index - 1] <= 0.1 <= times[index]
-            expected =
-                vals[index - 1] +
-                (vals[index] - vals[index - 1]) /
-                (times[index] - times[index - 1]) * (0.1 - times[index - 1])
-
-            @test Array(parent(dest))[1] ≈ expected
-
-            # Check edge case
-            TimeVaryingInputs.evaluate!(dest, input, 0.0)
-
-            @test Array(parent(dest))[1] ≈ 0.0
-
-            # Linear interpolation with PeriodicCalendar
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[10],
-            )
-            @test Array(parent(dest))[1] == vals[10]
-
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[1],
-            )
-            @test Array(parent(dest))[1] == vals[1]
-
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[end],
-            )
-            @test Array(parent(dest))[1] == vals[end]
-
-            # t_end + dt is equivalent to t_init
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[end] + dt,
-            )
-            @test Array(parent(dest))[1] ≈ vals[1]
-
-            # t_end + 2dt is equivalent to t_init + dt
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[end] + 2dt,
-            )
-            @test Array(parent(dest))[1] ≈ vals[2]
-
-            # In between t_end and t_init
-            expected = vals[end] + (vals[begin] - vals[end]) / dt * 0.1dt
-            TimeVaryingInputs.evaluate!(
-                dest,
-                input_periodic_calendar_linear,
-                times[end] + 0.1dt,
-            )
-            @test Array(parent(dest))[1] ≈ expected
         end
     end
 end


### PR DESCRIPTION
Add tests for TimeVaryingInput0D for 0D TVI
with times of floats, ITime with no epoch, and ITime with epoch.

Tests 0d TVI of floats can evaluate at ITime inputs, floating point inputs, and tests that an error is thrown with a datetime input.

Test that error is thrown when evaluating a TVI of ITimes with no epoch at a DateTime.

Test that TVI of ITime with epoch can be evaluated at ITimes, floats, or DateTimes.

Test that TVI of ITime with no epoch can be evaluated at ITimes or floats.

Make all the above tests pass by adding conversions to the `evaluate!` methods.

Add `Float64(::ITime)` and `Float32(::Time)`


Tried changing ITime and floating point  multiplication behavior to attempt to use a smaller period if the result of the multiplication is less than 1, but that is a behavior change, so I reverted it

<!--- THESE LINES ARE COMMENTED -->
## Purpose 
<!--- One sentence to describe the purpose of this PR, refer to any linked issues:
#14 -- this will link to issue 14
Closes #2 -- this will automatically close issue 2 on PR merge
-->



<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
