### PR TITLE
remove LatLongZ regridding warning; remove Julia nightly test; tag patch release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,6 @@ jobs:
         version:
           - '1.10'
           - '1.11'
-          - 'nightly'
         os:
           - ubuntu-latest
           - macOS-latest

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
-version = "0.1.25"
+version = "0.1.26"
 
 [deps]
 Artifacts = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"

--- a/ext/InterpolationsRegridderExt.jl
+++ b/ext/InterpolationsRegridderExt.jl
@@ -120,7 +120,6 @@ function Regridders.regrid(regridder::InterpolationsRegridder, data, dimensions)
        ) &&
        length(dimensions) == 2
 
-        @warn "Regridding 2D data onto a 2D space with LatLongZ coordinates."
         coords = map(regridder.coordinates) do coord
             ClimaCore.Geometry.LatLongPoint(coord.lat, coord.long)
         end

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -301,15 +301,6 @@ end
         check_lon_error(coordinates.long, regridded_lon_3d)
 
         # 2D data
-        @test_logs (
-            :warn,
-            "Regridding 2D data onto a 2D space with LatLongZ coordinates.",
-        ) Regridders.regrid(reg_2d, data_lat2D, dimensions2D)
-        @test_logs (
-            :warn,
-            "Regridding 2D data onto a 2D space with LatLongZ coordinates.",
-        ) Regridders.regrid(reg_2d, data_lon2D, dimensions2D)
-
         regridded_lat_2d = Regridders.regrid(reg_2d, data_lat2D, dimensions2D)
         regridded_lon_2d = Regridders.regrid(reg_2d, data_lon2D, dimensions2D)
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
In ClimaLand this warning comes up mulitiple times per simulation and clogs the output log.

As of this recent PR https://github.com/JuliaLang/julia/pull/59238, StaticData no longer exists in the nightly Julia version. This module is accessed somewhere in ClimaTimeSteppers/StaticArrayInterface/FastBroadcast/DiffEqBase. We shouldn't rely on upstream packages being compatible with the main branch of Julialang anyway, so I'm removing the nightly Julia tests.

## Content
- [x] limit log to print once
- [x] remove nightly Julia test
- [x] tag v0.1.26
