### PR TITLE
Change TVI0d constructor to conditionally promote

### DIFF
--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -76,6 +76,30 @@ end
         method = TimeVaryingInputs.LinearPeriodFillingInterpolation(),
     )
 
+    # test promote when some input times do not contain an epoch
+    promotion_tvi = TimeVaryingInputs.TimeVaryingInput(
+        [ITime(0; epoch = DateTime(2010)), ITime(2; period = Dates.Day(1))],
+        ys,
+    )
+    @test all(t -> t.epoch == DateTime(2010), promotion_tvi.times)
+    @test all(t -> t.period == Dates.Second(1), promotion_tvi.times)
+
+
+    # test with ITimes with different Epochs
+    @test_throws ErrorException TimeVaryingInputs.TimeVaryingInput(
+        [ITime(0; epoch = DateTime(2010)), ITime(1; epoch = DateTime(2011))],
+        ys,
+    )
+
+    # test with non-uniformly spaced ITimes
+    @test_throws ErrorException TimeVaryingInputs.TimeVaryingInput(
+        [ITime(0; epoch = DateTime(2010)), ITime(1), ITime(3), ITime(4)],
+        [1.0, 2.0, 3.0, 4.0];
+        method = TimeVaryingInputs.NearestNeighbor(
+            TimeVaryingInputs.PeriodicCalendar(),
+        ),
+    )
+
     # Test PeriodicCalendar with non simple duration
     @test_throws ErrorException TimeVaryingInputs.PeriodicCalendar(
         Month(2),


### PR DESCRIPTION
Promoting a large number of ITimes is expensive, so this modifies the behavior to only do so if needed.

Closes #186


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
