### PR TITLE
Cache on file reads and make copy of data

### DIFF
--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -129,14 +129,13 @@ function FileReaders.NCFileReader(
 
     # Get dataset from global dictionary. If not available, open the new dataset and add
     # entry to global dictionary
-    dataset, open_varnames = get!(
-        OPEN_NCFILES,
-        file_paths,  # We map the collection of files to the dataset
+    # We map the collection of files to the dataset
+    dataset, open_varnames = get!(OPEN_NCFILES, file_paths) do
         (
             NCDatasets.NCDataset(file_path_to_ncdataset; aggtime_kwarg...),
             Set([varname]),
-        ),
-    )
+        )
+    end
     # push! will do nothing when file is opened for the first time
     push!(open_varnames, varname)
 

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -233,31 +233,31 @@ function FileReaders.read(file_reader::NCFileReader, date::Dates.DateTime)
     # return _cached_reads[date], modifying the return value would modify the private state
     # of the file reader)
 
-    if haskey(file_reader._cached_reads, date)
-        return copy(file_reader._cached_reads[date])
-    end
-
     # DateTime(0) is the sentinel value for static datasets
     if date == Dates.DateTime(0)
-        return get!(file_reader._cached_reads, date) do
-            file_reader.preprocess_func.(
-                Array(file_reader.dataset[file_reader.varname]),
-            )
-        end
+        return copy(
+            get!(file_reader._cached_reads, date) do
+                file_reader.preprocess_func.(
+                    Array(file_reader.dataset[file_reader.varname]),
+                )
+            end,
+        )
     end
 
-    index = findall(d -> d == date, file_reader.available_dates)
-    length(index) == 1 ||
-        error("Problem with date $date in one of $(file_reader.file_paths)")
-    index = index[]
-
-    var = file_reader.dataset[file_reader.varname]
-    slicer = [
-        i == file_reader.time_index ? index : Colon() for
-        i in 1:length(NCDatasets.dimnames(var))
-    ]
-    return file_reader.preprocess_func.(
-        file_reader.dataset[file_reader.varname][slicer...],
+    return copy(
+        get!(file_reader._cached_reads, date) do
+            index = findall(d -> d == date, file_reader.available_dates)
+            length(index) == 1 || error(
+                "Problem with date $date in one of $(file_reader.file_paths)",
+            )
+            index = index[]
+            var = file_reader.dataset[file_reader.varname]
+            slicer = [
+                i == file_reader.time_index ? index : Colon() for
+                i in 1:length(NCDatasets.dimnames(var))
+            ]
+            file_reader.preprocess_func.(var[slicer...])
+        end,
     )
 end
 
@@ -280,11 +280,13 @@ function FileReaders.read(file_reader::NCFileReader)
         error("File contains temporal data, date required")
 
     # When there's no dates, we use DateTime(0) as key
-    return get!(file_reader._cached_reads, Dates.DateTime(0)) do
-        return file_reader.preprocess_func.(
-            Array(file_reader.dataset[file_reader.varname]),
-        )
-    end
+    return copy(
+        get!(file_reader._cached_reads, Dates.DateTime(0)) do
+            file_reader.preprocess_func.(
+                Array(file_reader.dataset[file_reader.varname]),
+            )
+        end,
+    )
 end
 
 """

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -37,6 +37,12 @@ using NCDatasets
         @test FileReaders.read(ncreader_u, DateTime(2021, 01, 01, 01)) ==
               nc["u10n"][:, :, 2]
 
+        # Mutating a read should not corrupt the cache
+        first_read = FileReaders.read(ncreader_u, DateTime(2021, 01, 01, 02))
+        fill!(first_read, NaN)
+        @test FileReaders.read(ncreader_u, DateTime(2021, 01, 01, 02)) ==
+              nc["u10n"][:, :, 3]
+
         # Test read!
         dest = copy(nc["u10n"][:, :, 2])
         fill!(dest, 0)
@@ -82,6 +88,12 @@ end
         @test ncreader.dimensions[1] == nc["lon"][:]
         @test ncreader.dimensions[2] == nc["lat"][:]
 
+        # This first read is a cache miss (using the DateTime(0) sentinel)
+        first_read = FileReaders.read(ncreader)
+        @test first_read == nc["u10n"][:, :]
+
+        # Mutating a read should not corrupt the cache
+        fill!(first_read, NaN)
         @test FileReaders.read(ncreader) == nc["u10n"][:, :]
 
         # Test read!


### PR DESCRIPTION
closes #221 - In `NCFileReaderExt`, any file reads for time varying data was not cached. Additionally, ownership of the data was not passed properly to the caller which lead to the caller having access to data stored in the cache. Finally, when initializing a `NCFileReader`, a `NCDataset` file handle was eagerly initialized instead of lazily initialized.