### PR TITLE
Pin JuliaFormatter to v2.10.1

### DIFF
--- a/.github/workflows/JuliaFormatter.yml
+++ b/.github/workflows/JuliaFormatter.yml
@@ -40,7 +40,7 @@ jobs:
     - name: Apply JuliaFormatter
       if: steps.filter.outputs.julia_file_change == 'true'
       run: |
-        julia -e 'using Pkg; Pkg.add("JuliaFormatter"); using JuliaFormatter; format(".")'
+        julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="2.10.1"); using JuliaFormatter; format(".")'
 
     - name: Check formatting diff
       if: steps.filter.outputs.julia_file_change == 'true'

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ consistent formatting. Here's how to use it:
 
 You can either install in your base environment with
 ``` sh
-julia -e 'using Pkg; Pkg.add("JuliaFormatter")'
+julia -e 'using Pkg; Pkg.add(name="JuliaFormatter", version="2.10.1")'
 ```
 or use it from within the `TestEnv` or the `.buildkite` environments (see previous section).
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -22,5 +22,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.8"
 ClimaTimeSteppers = "0.8.2"
+JuliaFormatter = "=2.10.1"
 SafeTestsets = "0.1"
 Test = "1"

--- a/test/onlinelogging.jl
+++ b/test/onlinelogging.jl
@@ -134,7 +134,7 @@ import ClimaUtilities.OnlineLogging:
         io = IOBuffer()
         dt = 3600.0
         n_steps = 32
-        tf = n_steps*dt
+        tf = n_steps * dt
         delay_s = 0.2
         reporting_times = (1, 2, 8, 16)
         Logging.with_logger(Logging.SimpleLogger(io)) do
@@ -186,15 +186,15 @@ import ClimaUtilities.OnlineLogging:
             s_and_ms_to_s(time_remaining_s, time_remaining_ms)
         reported_time_total = s_and_ms_to_s(time_total_s, time_total_ms)
         theoretical_time_total = delay_s * n_steps
-        theoretical_sypd = (24*3600) / (delay_s * 365 * 24 * 3600.0 / dt)
+        theoretical_sypd = (24 * 3600) / (delay_s * 365 * 24 * 3600.0 / dt)
         @test isapprox(
             reported_time_remaining,
-            theoretical_time_total/2;
+            theoretical_time_total / 2;
             rtol = 0.1,
         )
         @test isapprox(
             reported_time_spent,
-            theoretical_time_total/2;
+            theoretical_time_total / 2;
             rtol = 0.1,
         )
         @test isapprox(reported_time_total, theoretical_time_total; rtol = 0.1)


### PR DESCRIPTION
## Summary
- Pin JuliaFormatter to an exact version (`2.10.1`) in the formatter GitHub Action, `test/Project.toml`, and the README so formatting is reproducible across CI and local runs.
- Reformat the codebase with JuliaFormatter v2.10.1 (whitespace/style only, no logic changes).

See [Pinning the JuliaFormatter version](https://juliaeditorsupport.github.io/JuliaFormatter.jl/stable/status/#Pinning-the-JuliaFormatter-version) for why pinning is recommended.

## Test plan
- [x] `git diff` reviewed — formatting-only changes
- [ ] CI passes