### PR TITLE
feat: add exact integer division for ITime

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,16 @@ ClimaUtilities.jl Release Notes
 main
 ------
 
+v0.1.31
+------
+
+### Exact integer division for `ITime`
+
+`ITime` now supports exact division by an integer, `t / num`.
+The result keeps the period of `t` when the counter is divisible, and is otherwise expressed in the largest unit period (week down to nanosecond) at which the division is exact.
+An error is thrown when no such period exists.
+This complements `div(t, num)`, which truncates the counter.
+
 v0.1.30
 ------
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,6 +14,10 @@ The result keeps the period of `t` when the counter is divisible, and is otherwi
 An error is thrown when no such period exists.
 This complements `div(t, num)`, which truncates the counter.
 
+### `seconds` accepts `Real`
+
+`seconds(t::Real)` returns `float(t)`, so code handling both `ITime` and floating-point times can call `seconds` uniformly.
+
 v0.1.30
 ------
 

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.30"
+version = "0.1.31"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
 
 [deps]

--- a/docs/src/timemanager.md
+++ b/docs/src/timemanager.md
@@ -108,6 +108,22 @@ time1 / time2
 In this case, the return value is just a number (essentially, we divided 15
 seconds by 5 seconds, resulting the dimensionless factor of 3).
 
+Dividing an `ITime` by an integer returns an `ITime`, and the division is exact.
+When the counter is not divisible by the integer, the result is expressed in the largest unit period (week down to nanosecond) at which the division is exact.
+```@example example1
+time1 = ITime(1; period = Hour(1))
+time1 / 2
+```
+When no period down to the nanosecond makes the division exact, an error is thrown.
+```@example example1
+try #hide
+ITime(1; period = Second(1)) / 3
+catch err; showerror(stderr, err); end #hide
+```
+The counter type is preserved, so the refined counter must be representable by it.
+For example, `ITime(Int32(2_000_000_001); period = Second(1)) / 2` needs a millisecond counter larger than `typemax(Int32)`, so an error is thrown.
+For a division that truncates the counter and keeps the period, use `div`.
+
 Similarly, adding a number to an `ITime` is not allowed (because the number
 doesn't have units), but multiplying by is fine.
 
@@ -308,4 +324,5 @@ Base.one(t::T) where {T <: ClimaUtilities.TimeManager.ITime}
 Base.oneunit(t::T) where {T <: ClimaUtilities.TimeManager.ITime}
 Base.zero(t::T) where {T <: ClimaUtilities.TimeManager.ITime}
 Base.:*(t::ClimaUtilities.TimeManager.ITime, a::AbstractFloat)
+Base.:/(t::ClimaUtilities.TimeManager.ITime, num::Integer)
 ```

--- a/src/ITime.jl
+++ b/src/ITime.jl
@@ -474,5 +474,79 @@ Base.:*(num::Integer, t::T) where {T <: ITime} =
 Base.:*(t::T, num::Integer) where {T <: ITime} =
     ITime(num * t.counter, t.period, t.epoch)
 
+"""
+    finer_unit_period(period::Dates.FixedPeriod)
+
+Return the next unit period after the unit of `period` in the sequence week,
+day, hour, minute, second, millisecond, microsecond, nanosecond, as a pair
+`(finer_period, ratio)` with `oneunit(period) == ratio * finer_period`.
+Return `nothing` when the unit of `period` is `Dates.Nanosecond`.
+"""
+finer_unit_period(::Dates.Week) = (Dates.Day(1), 7)
+finer_unit_period(::Dates.Day) = (Dates.Hour(1), 24)
+finer_unit_period(::Dates.Hour) = (Dates.Minute(1), 60)
+finer_unit_period(::Dates.Minute) = (Dates.Second(1), 60)
+finer_unit_period(::Dates.Second) = (Dates.Millisecond(1), 1000)
+finer_unit_period(::Dates.Millisecond) = (Dates.Microsecond(1), 1000)
+finer_unit_period(::Dates.Microsecond) = (Dates.Nanosecond(1), 1000)
+finer_unit_period(::Dates.Nanosecond) = nothing
+
+"""
+    refine_period(period::Dates.FixedPeriod)
+
+Return the next step in the period-refinement sequence as a pair
+`(finer_period, ratio)` with `period == ratio * finer_period`: a multiple-unit
+period refines to its unit period, and a unit period to the next finer unit
+period. Return `nothing` for `Dates.Nanosecond(1)`.
+"""
+function refine_period(period::Dates.FixedPeriod)
+    n = Dates.value(period)
+    n == 1 || return (typeof(period)(1), n)
+    return finer_unit_period(period)
+end
+
+"""
+    Base.:/(t::ITime, num::Integer)
+
+Divide an `ITime` by an integer exactly, so that `num * (t / num) == t`.
+
+When `counter(t)` is divisible by `num`, the result keeps the period of `t`.
+Otherwise the result is expressed in the largest unit period, from week down
+to nanosecond and no larger than the unit of the period of `t`, at which the
+division is exact; for example, `ITime(1; period = Dates.Hour(1)) / 2` is 30
+minutes. An error is thrown when the division is not exact at any such period
+(e.g. `ITime(1; period = Dates.Second(1)) / 3`) or when the resulting counter
+is not representable by the counter type of `t`.
+
+Unlike `div(t, num)`, which truncates the counter, this division is exact.
+"""
+function Base.:/(t::ITime, num::Integer)
+    iszero(num) && throw(DivideError())
+    INT = typeof(t.counter)
+    WIDE = promote_type(INT, Int64)
+    c = WIDE(t.counter)
+    num_signed = promote_type(typeof(num), Int64)(num)
+    remaining = WIDE(Base.Checked.checked_abs(num_signed))
+    common = gcd(c, remaining)
+    c = div(c, common)
+    remaining = div(remaining, common)
+    current_period = t.period
+    while !isone(remaining)
+        step = refine_period(current_period)
+        isnothing(step) && error(
+            "Cannot represent $t / $num as an integer multiple of a nanosecond or coarser period",
+        )
+        current_period, ratio = step
+        common = gcd(WIDE(ratio), remaining)
+        c = Base.Checked.checked_mul(c, div(WIDE(ratio), common))
+        remaining = div(remaining, common)
+    end
+    new_counter = num < 0 ? Base.Checked.checked_neg(c) : c
+    INT === WIDE ||
+        typemin(INT) <= new_counter <= typemax(INT) ||
+        error("The counter of $t / $num is not representable as $INT")
+    return ITime(INT(new_counter), current_period, t.epoch)
+end
+
 # Behave as a scalar when broadcasted
 Base.Broadcast.broadcastable(t::ITime) = Ref(t)

--- a/src/ITime.jl
+++ b/src/ITime.jl
@@ -90,12 +90,17 @@ end
 
 """
     seconds(t::ITime)
+    seconds(t::Real)
 
 Return the time represented by `t` in seconds, as a floating-point number.
+
+For a plain `Real`, the value is assumed to already be in seconds and is
+returned as a floating-point number.
 """
 function seconds(t::ITime)
     return float(t)
 end
+seconds(t::Real) = float(t)
 
 # Accessors
 """

--- a/test/itime.jl
+++ b/test/itime.jl
@@ -145,6 +145,11 @@ using Test, Dates
         @test_throws ErrorException t6 + t7
     end
 
+    @testset "seconds of a Real" begin
+        @test TimeManager.seconds(2.5) === 2.5
+        @test TimeManager.seconds(3) === 3.0
+    end
+
     @testset "Divide an ITime by an integer" begin
         # Exact at the current period, period and counter type preserved
         t1 = ITime(10, period = Dates.Second(1))

--- a/test/itime.jl
+++ b/test/itime.jl
@@ -145,6 +145,121 @@ using Test, Dates
         @test_throws ErrorException t6 + t7
     end
 
+    @testset "Divide an ITime by an integer" begin
+        # Exact at the current period, period and counter type preserved
+        t1 = ITime(10, period = Dates.Second(1))
+        @test t1 / 2 == ITime(5, period = Dates.Second(1))
+        @test (t1 / 2).period == Dates.Second(1)
+        @test 2 * float(t1 / 2) == float(t1)
+
+        # Result in the largest unit period where the division is exact
+        t2 = ITime(1, period = Dates.Second(1))
+        @test t2 / 4 == ITime(250, period = Dates.Millisecond(1))
+        @test (t2 / 4).period == Dates.Millisecond(1)
+        @test 4 * float(t2 / 4) == float(t2)
+
+        @test t2 / 2500 == ITime(400, period = Dates.Microsecond(1))
+        @test (t2 / 2500).period == Dates.Microsecond(1)
+
+        @test t2 / 2_000_000 == ITime(500, period = Dates.Nanosecond(1))
+        @test (t2 / 2_000_000).period == Dates.Nanosecond(1)
+
+        # Refinement from a sub-second period
+        t3 = ITime(1, period = Dates.Millisecond(1))
+        @test t3 / 2 == ITime(500, period = Dates.Microsecond(1))
+
+        # Refinement from periods coarser than a second
+        @test ITime(1, period = Dates.Week(1)) / 7 ==
+              ITime(1, period = Dates.Day(1))
+        @test ITime(1, period = Dates.Day(1)) / 2 ==
+              ITime(12, period = Dates.Hour(1))
+        @test (ITime(1, period = Dates.Hour(1)) / 2).period == Dates.Minute(1)
+        @test ITime(1, period = Dates.Hour(1)) / 2 ==
+              ITime(30, period = Dates.Minute(1))
+        @test ITime(1, period = Dates.Minute(1)) / 4 ==
+              ITime(15, period = Dates.Second(1))
+
+        # The result of a multiple-unit period is no coarser than its unit
+        @test ITime(3, period = Dates.Millisecond(100)) / 2 ==
+              ITime(150, period = Dates.Millisecond(1))
+        @test (ITime(3, period = Dates.Millisecond(100)) / 2).period ==
+              Dates.Millisecond(1)
+        @test ITime(3, period = Dates.Hour(2)) / 4 ==
+              ITime(90, period = Dates.Minute(1))
+
+        # Negative counters and divisors
+        @test ITime(-1, period = Dates.Second(1)) / 4 ==
+              ITime(-250, period = Dates.Millisecond(1))
+        @test ITime(1, period = Dates.Second(1)) / -4 ==
+              ITime(-250, period = Dates.Millisecond(1))
+        @test ITime(-1, period = Dates.Second(1)) / -4 ==
+              ITime(250, period = Dates.Millisecond(1))
+
+        # 500 years (of 365 days) exceed typemax(Int64) nanoseconds (see #232)
+        @test (
+            ITime(500 * 365, period = Dates.Day(1)) +
+            ITime(1, period = Dates.Second(1))
+        ) / 2 ==
+              ITime(250 * 365, period = Dates.Day(1)) +
+              ITime(500, period = Dates.Millisecond(1))
+
+        # 270 million years; the millisecond result still fits the counter (see #232)
+        @test (
+            ITime(270_000_000 * 365, period = Dates.Day(1)) +
+            ITime(1, period = Dates.Second(1))
+        ) / 2 ==
+              ITime(135_000_000 * 365, period = Dates.Day(1)) +
+              ITime(500, period = Dates.Millisecond(1))
+
+        # Not representable at any period down to the nanosecond
+        @test_throws ErrorException ITime(1, period = Dates.Second(1)) / 3
+        @test_throws ErrorException ITime(1, period = Dates.Nanosecond(1)) / 2
+        @test_throws DivideError ITime(1, period = Dates.Second(1)) / 0
+
+        # 30 billion years; the millisecond result overflows Int64
+        @test_throws OverflowError (
+            ITime(30_000_000_000 * 365, period = Dates.Day(1)) +
+            ITime(1, period = Dates.Second(1))
+        ) / 2
+        @test_throws OverflowError ITime(
+            typemin(Int64),
+            period = Dates.Second(1),
+        ) / -1
+
+        # Result does not fit the counter type
+        @test_throws ErrorException ITime(
+            Int32(2_000_000_001),
+            period = Dates.Second(1),
+        ) / 2
+
+        # Unsigned counters reject a negative result
+        @test ITime(UInt64(10), period = Dates.Second(1)) / 2 ==
+              ITime(UInt64(5), period = Dates.Second(1))
+        @test_throws OverflowError ITime(UInt64(10), period = Dates.Second(1)) /
+                                   -2
+
+        # BigInt counters
+        @test ITime(big(10), period = Dates.Second(1)) / 4 ==
+              ITime(big(2500), period = Dates.Millisecond(1))
+        @test typeof((ITime(big(10), period = Dates.Second(1)) / 4).counter) ==
+              BigInt
+        @test ITime(big(10), period = Dates.Second(1)) / -4 ==
+              ITime(big(-2500), period = Dates.Millisecond(1))
+
+        # Epoch preservation
+        epoch = Dates.DateTime(2020, 1, 1)
+        t4 = ITime(1, period = Dates.Second(1), epoch = epoch)
+        @test (t4 / 2).epoch == epoch
+        @test (t4 / 4).epoch == epoch
+
+        # Counter type preservation
+        t5 = ITime(Int32(4), period = Dates.Second(1))
+        @test typeof((t5 / 2).counter) == Int32
+        t6 = ITime(Int32(1), period = Dates.Second(1))
+        @test (t6 / 4) == ITime(Int32(250), period = Dates.Millisecond(1))
+        @test typeof((t6 / 4).counter) == Int32
+    end
+
     @testset "Float Conversion and Broadcasting" begin
         t1 = ITime(10, period = Dates.Millisecond(100))
         @test float(t1) == 1.0


### PR DESCRIPTION
Add `Base.:/(t::ITime, num::Integer)`

When the counter is divisible, the result keeps the current period and counter type. Otherwise the result takes the largest unit period (week down to nanosecond) at which the division is exact: `ITime(1, period = Second(1)) / 4` is 250 ms, and `ITime(1, period = Hour(1)) / 2` is 30 minutes. The division throws when no such period exists (`1 s / 3`) or the resulting counter does not fit the counter type; division by zero throws `DivideError`. `div(t, num)` is unchanged: it truncates at the current period, as `div` does for other numeric types.

**Motivation:** sub-stepping wants `dt / n_sub` exact so every sub-step is identical[^1]. 
`div` truncates: `div(ITime(10, period = Second(1)), 4)` is 2 s, and a sub-cycle built on it covers 8 of the 10 seconds, while `ITime(10, period = Second(1)) / 4` is exactly 2500 ms. 

An invalid count (the same step divided by 3) throws at configuration time instead of silently undershooting. First use case: the acoustic-substepping driver behind CliMA/ClimaTimeSteppers.jl#442 and CliMA/ClimaAtmos.jl#4660.

[^1]: We could instead absorb the division remainder by extending one sub-step

**Verification:** the `test/itime.jl` testset covers division at the current period, refinement from every unit period, multiple-unit periods (`Millisecond(100)`, `Hour(2)`), negative counters and divisors, a division beyond `typemax(Int64)` nanoseconds that succeeds exactly (500 years of 365 days, halved), the non-representable, overflow, and divide-by-zero errors, and epoch and counter-type preservation (`Int32` stays `Int32`; `UInt64` and `BigInt` are exercised).

The behavior is documented on the ITime documentation page, and the docstring is listed in the TimeManager API block. `seconds` also gains a `Real` method (the value is taken to already be in seconds), so call sites handling either time representation can use the unit-explicit name instead of `float`.