### PR TITLE
Bump patch version to 0.1.30; Reduce flaky  test

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,9 +3,17 @@ ClimaUtilities.jl Release Notes
 
 main
 ------
-### Minor additions
+
+v0.1.30
+------
+
+### Minor additions and bug fixes
 
 - Remove unnecessary allocations in `FileReaders.read` and `FileReaders.read!`.
+- `FileReaders.read` now caches reads for all dates (not just static datasets)
+  and returns a copy so that the cached, internal state cannot be mutated by
+  the caller.
+- Updated compat entries for `CUDA.jl` (to v6) and `Interpolations.jl` (to v0.16).
 
 v0.1.29
 ------

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.29"
+version = "0.1.30"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
 
 [deps]

--- a/test/onlinelogging.jl
+++ b/test/onlinelogging.jl
@@ -197,9 +197,9 @@ import ClimaUtilities.OnlineLogging:
             theoretical_time_total / 2;
             rtol = 0.1,
         )
-        @test isapprox(reported_time_total, theoretical_time_total; rtol = 0.1)
-        @test isapprox(reported_sypd, theoretical_sypd; rtol = 0.1)
-        @test isapprox(inst_sypd, theoretical_sypd; rtol = 0.1)
+        @test isapprox(reported_time_total, theoretical_time_total; rtol = 0.25)
+        @test isapprox(reported_sypd, theoretical_sypd; rtol = 0.25)
+        @test isfinite(inst_sypd) && inst_sypd > 0
     end
 
     @testset "_time_and_units_str" begin


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
Tag a patch release so downstream compats can be updated for CUDA.jl and Interpolations.jl

This PR also has a commit that hopefully makes the onlinelogging tests less flaky. 

I thought these tests would be useful, but they
are flaky. I can't think of a better way to test functionality
of the reporting though. This commit widens the bounds for
reported_time_total and reported_sypd vs their theoretical values.
I chose rtol values that should only fail if something has gone wrong.
This commit also changes the instantaneous sypd test to only check that
the reported value is positive and finite. This is because it is the
most prone to noise.

Alternatively, I can just delete the timing component of the tests, and only check that it is reporting positive values.


<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
