### PR TITLE
Fix interpolation bug with Flat extrapolation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,11 @@ ClimaUtilities.jl Release Notes
 
 main
 ------
+### Bug fixes
+
+- Fix bug where 0D and 2D/3D `TimeVaryingInput`s using the `Flat()`
+  extrapolation boundary condition did not interpolate correctly for dates
+  within the range of available dates.
 
 v0.1.30
 ------

--- a/ext/TimeVaryingInputs0DExt.jl
+++ b/ext/TimeVaryingInputs0DExt.jl
@@ -149,11 +149,12 @@ function _evaluate_flat!(dest, itp::InterpolatingTimeVaryingInput0D, time)
     t_init, t_end = itp.range
     if time >= t_end
         dest .= itp.vals[end]
-    else
-        time <= t_init
+        return true
+    elseif time <= t_init
         dest .= itp.vals[begin]
+        return true
     end
-    return nothing
+    return false
 end
 
 function _time_range_target_time_dt(itp::InterpolatingTimeVaryingInput0D, time)
@@ -172,8 +173,7 @@ function TimeVaryingInputs.evaluate!(
     # Nearest neighbor interpolation: just pick the values corresponding to the entry in
     # itp.times that is closest to the given time.
     if extrapolation_bc(itp.method) isa Flat
-        _evaluate_flat!(dest, itp, time)
-        return nothing
+        _evaluate_flat!(dest, itp, time) && return nothing
     elseif extrapolation_bc(itp.method) isa PeriodicCalendar{Nothing}
         t_init, t_end, time, dt = _time_range_target_time_dt(itp, time)
         # Now time is between t_init and t_end + dt. We are doing nearest neighbor
@@ -206,8 +206,7 @@ function TimeVaryingInputs.evaluate!(
     ::LinearInterpolation,
 )
     if extrapolation_bc(itp.method) isa Flat
-        _evaluate_flat!(dest, itp, time)
-        return nothing
+        _evaluate_flat!(dest, itp, time) && return nothing
     elseif extrapolation_bc(itp.method) isa PeriodicCalendar
         t_init, t_end, time, dt = _time_range_target_time_dt(itp, time)
         # We have to handle separately the edge case where the desired time is past t_end.

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -214,9 +214,10 @@ function TimeVaryingInputs.evaluate!(
         itp.data_handler.available_dates[end]
         if time >= date_end
             regridded_snapshot!(dest, itp.data_handler, date_end)
-        else
-            time <= date_init
+        elseif time <= date_init
             regridded_snapshot!(dest, itp.data_handler, date_init)
+        else
+            TimeVaryingInputs.evaluate!(dest, itp, time, itp.method)
         end
     else
         TimeVaryingInputs.evaluate!(dest, itp, time, itp.method)

--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -181,6 +181,15 @@ end
                 ),
             )
 
+            # Linear interpolation with Flat
+            input_flat_linear = TimeVaryingInputs.TimeVaryingInput(
+                times,
+                vals;
+                method = TimeVaryingInputs.LinearInterpolation(
+                    TimeVaryingInputs.Flat(),
+                ),
+            )
+
             # Nearest neighbor interpolation with PeriodicCalendar
             input_periodic_calendar = TimeVaryingInputs.TimeVaryingInput(
                 times,
@@ -234,6 +243,22 @@ end
                     ft_to_input(FT(400)),
                 )
                 @test Array(parent(dest))[1] == vals[end]
+
+                # Time inside of range with Flat
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_clamp,
+                    time_to_input(times[10]),
+                )
+                @test Array(parent(dest))[1] == vals[10]
+
+                # Time inside of range, between snapshots, with Flat
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_clamp,
+                    time_to_input(times[10] + 0.3dt),
+                )
+                @test Array(parent(dest))[1] == vals[10]
 
                 # Time outside of range with PeriodicCalendar
                 TimeVaryingInputs.evaluate!(
@@ -289,6 +314,15 @@ end
                 input = TimeVaryingInputs.TimeVaryingInput(times, vals)
 
                 TimeVaryingInputs.evaluate!(dest, input, ft_to_input(FT(10)))
+                linear_in_range = Array(parent(dest))[1]
+
+                # Time in range with Flat
+                TimeVaryingInputs.evaluate!(
+                    dest,
+                    input_flat_linear,
+                    ft_to_input(FT(10)),
+                )
+                @test Array(parent(dest))[1] ≈ linear_in_range
 
                 if eltype(time) <: Number
                     # searchsortedfirst only needs to work with floats, as TVI0d will

--- a/test/time_varying_inputs23.jl
+++ b/test/time_varying_inputs23.jl
@@ -370,6 +370,51 @@ include("TestTools.jl")
                     )
                 end
 
+                # Flat, in range (exact snapshot)
+                target_time = available_times[10]
+                target_date = available_dates[10]
+                for t in (
+                    target_time,
+                    target_date,
+                    ITime(0, epoch = available_dates[10]),
+                )
+                    TimeVaryingInputs.evaluate!(dest, input_nearest_flat, t)
+
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[10],
+                                ),
+                            ),
+                        ),
+                    )
+                end
+
+                # Flat, in range (between snapshots)
+                dt = available_times[11] - available_times[10]
+                d_date = available_dates[11] - available_dates[10]
+                target_time = available_times[10] + 0.3dt
+                target_date = available_dates[10] + 0.3d_date
+                for t in
+                    (target_time, target_date, ITime(0, epoch = target_date))
+                    TimeVaryingInputs.evaluate!(dest, input_nearest_flat, t)
+
+                    @test isequal(
+                        Array(parent(dest)),
+                        Array(
+                            parent(
+                                DataHandling.regridded_snapshot(
+                                    data_handler,
+                                    available_times[10],
+                                ),
+                            ),
+                        ),
+                    )
+                end
+
                 # Nearest periodic calendar
                 dt = available_times[2] - available_times[1]
                 target_time = available_times[end] + 0.1dt
@@ -445,6 +490,12 @@ include("TestTools.jl")
 
                 # Now testing LinearInterpolation
                 input_linear = TimeVaryingInputs.TimeVaryingInput(data_handler)
+                input_linear_flat = TimeVaryingInputs.TimeVaryingInput(
+                    data_handler;
+                    method = TimeVaryingInputs.LinearInterpolation(
+                        TimeVaryingInputs.Flat(),
+                    ),
+                )
 
                 # Time outside of range
                 @test_throws ErrorException TimeVaryingInputs.evaluate!(
@@ -482,6 +533,9 @@ include("TestTools.jl")
                 for t in
                     (target_time, target_date, ITime(0, epoch = target_date))
                     TimeVaryingInputs.evaluate!(dest, input_linear, t)
+                    @test parent(dest) ≈ parent(expected)
+
+                    TimeVaryingInputs.evaluate!(dest, input_linear_flat, t)
                     @test parent(dest) ≈ parent(expected)
                 end
 
@@ -537,6 +591,7 @@ include("TestTools.jl")
                 close(input_multiple_vars)
                 close(input_nearest)
                 close(input_linear)
+                close(input_linear_flat)
                 close(input_nearest_flat)
                 close(input_nearest_periodic_calendar)
                 close(input_linear_periodic_calendar)


### PR DESCRIPTION
closes #235 - This PR fixes a bug with the `Flat` extrapolation boundary condition. If the date used for interpolation was before or is the last available date, the interpolation was not correct. This affected both the 0D and 2D/3D time varying inputs.

I asked Claude to make these changes and I verified that they are correct.