### PR TITLE
Add support for multiple columns interpolation

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -13,10 +13,12 @@ Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
 CUDA = "052768ef-5323-5732-b1bb-66c8b64840ba"
 ClimaCore = "d414da3d-4745-48bb-8d80-42e94e092884"
 ClimaCoreTempestRemap = "d934ef94-cdd4-4710-83d6-720549644b70"
+ClimaInterpolations = "dd0f122e-fa3b-47f3-bcf0-93bbc60d885e"
 Interpolations = "a98d9a8b-a2ab-59e6-89dd-64a1c18fca59"
 NCDatasets = "85f8d34a-cbdd-5861-8df4-14fed0d494ab"
 
 [extensions]
+ClimaUtilitiesClimaCoreClimaInterpolationsExt = ["ClimaCore", "ClimaInterpolations"]
 ClimaUtilitiesClimaCoreExt = "ClimaCore"
 ClimaUtilitiesClimaCoreInterpolationsExt = ["ClimaCore", "Interpolations"]
 ClimaUtilitiesClimaCoreNCDatasetsExt = ["ClimaCore", "NCDatasets"]
@@ -30,6 +32,7 @@ CUDA = "5.5, 6"
 ClimaComms = "0.6.2"
 ClimaCore = "0.14.23"
 ClimaCoreTempestRemap = "0.3.15"
+ClimaInterpolations = "0.1.1"
 Dates = "1"
 Interpolations = "0.15.1, 0.16"
 NCDatasets = "0.14"

--- a/docs/src/datahandling.md
+++ b/docs/src/datahandling.md
@@ -186,6 +186,7 @@ data_handler = DataHandling.DataHandler("era5_example.nc",
 
 ```@docs
 ClimaUtilities.DataHandling.DataHandler
+ClimaUtilities.DataHandling.MultiColumnDataHandler
 ClimaUtilities.DataHandling.available_times
 ClimaUtilities.DataHandling.available_dates
 ClimaUtilities.DataHandling.previous_time

--- a/docs/src/filereaders.md
+++ b/docs/src/filereaders.md
@@ -93,6 +93,7 @@ files in the correct order.
 
 ```@docs
 ClimaUtilities.FileReaders.NCFileReader
+ClimaUtilities.FileReaders.DatasetSource
 ClimaUtilities.FileReaders.read
 ClimaUtilities.FileReaders.read!
 ClimaUtilities.FileReaders.available_dates

--- a/docs/src/filereaders.md
+++ b/docs/src/filereaders.md
@@ -93,7 +93,8 @@ files in the correct order.
 
 ```@docs
 ClimaUtilities.FileReaders.NCFileReader
-ClimaUtilities.FileReaders.DatasetSource
+ClimaUtilities.FileReaders.MultiColumnNCFileReader
+ClimaUtilities.FileReaders.DataSource
 ClimaUtilities.FileReaders.read
 ClimaUtilities.FileReaders.read!
 ClimaUtilities.FileReaders.available_dates

--- a/docs/src/regridders.md
+++ b/docs/src/regridders.md
@@ -4,7 +4,7 @@ Simulations often need to import external data directly onto the computational
 grid. The `Regridders` module implements different schemes to accomplish this
 goal.
 
-Currently, `Regridders` comes with two implementations:
+Currently, `Regridders` comes with three implementations:
 1. `TempestRegridder` uses
    [TempestRemap](https://github.com/ClimateGlobalChange/tempestremap) (through
    `ClimaCoreTempestRemap`) to perform conservative interpolation onto lat-long
@@ -14,6 +14,10 @@ Currently, `Regridders` comes with two implementations:
    [Interpolations.jl](https://github.com/JuliaMath/Interpolations.jl) to
    perform non-conservative linear interpolation onto lat-long(-z) and x-y-z grids.
    `InterpolationsRegridder` works directly with data.
+3. `ColumnRegridder` uses
+   [ClimaInterpolations.jl](https://github.com/CliMA/ClimaInterpolations.jl) to
+   perform vertical-only interpolation of column data. `ColumnRegridder` works
+   directly with data.
 
 !!! note
 
@@ -115,10 +119,24 @@ interpolated_data = Regridders.InterpolationsRegridder(reg, data, dimensions)
 interpolated_2data = Regridders.InterpolationsRegridder(reg, 2 .* data, dimensions)
 ```
 
+## `ColumnRegridder`
+
+> This extension is loaded when loading `ClimaCore` and `ClimaInterpolations`
+
+`ColumnRegridder` interpolates data defined on each column's vertical levels
+onto the vertical levels of a multi-column `target_space`. It performs no
+horizontal interpolation: the columns of the data are assumed to already be
+aligned with the columns of the target space.
+
+`ColumnRegridder` is special-purpose and is never selected by
+`default_regridder_type()`: it is used through `MultiColumnDataHandler`, which
+must be constructed explicitly (see the `DataHandling` documentation).
+
 ## API
 
 ```@docs
 ClimaUtilities.Regridders.TempestRegridder
 ClimaUtilities.Regridders.InterpolationsRegridder
+ClimaUtilities.Regridders.ColumnRegridder
 ClimaUtilities.Regridders.regrid
 ```

--- a/ext/ClimaUtilitiesClimaCoreClimaInterpolationsExt.jl
+++ b/ext/ClimaUtilitiesClimaCoreClimaInterpolationsExt.jl
@@ -1,0 +1,5 @@
+module ClimaUtilitiesClimaCoreClimaInterpolationsExt
+
+include("ColumnRegridderExt.jl")
+
+end

--- a/ext/ClimaUtilitiesNCDatasetsExt.jl
+++ b/ext/ClimaUtilitiesNCDatasetsExt.jl
@@ -1,5 +1,7 @@
 module ClimaUtilitiesNCDatasetsExt
 
+include("DataSourceExt.jl")
+
 include("NCFileReaderExt.jl")
 
 end

--- a/ext/ColumnRegridderExt.jl
+++ b/ext/ColumnRegridderExt.jl
@@ -1,0 +1,236 @@
+module ColumnRegridderExt
+
+import ClimaInterpolations
+
+import ClimaCore
+import ClimaComms
+
+import ClimaUtilities.Regridders
+
+"""
+    ColumnRegridder
+
+A regridder that interpolates data on each column's vertical levels onto the
+vertical levels of `target_space`, using `ClimaInterpolations.jl`. If there are
+no vertical levels, then no vertical interpolation is done.
+
+Unlike `InterpolationsRegridder`, this does no horizontal interpolation. The
+columns are assumed to already be aligned with the target space's columns.
+"""
+struct ColumnRegridder{
+    SPACE <: ClimaCore.Spaces.AbstractSpace,
+    OR,
+    EX,
+    SRC <: AbstractArray,
+    TARGET <: AbstractArray,
+    SCR <: Union{AbstractArray, Nothing},
+} <: Regridders.AbstractRegridder
+    """ClimaCore space to interpolate onto."""
+    target_space::SPACE
+
+    """Interpolation order (e.g.
+    `ClimaInterpolations.Interpolation1D.Linear()`)."""
+    order::OR
+
+    """Extrapolation condition (e.g.
+    `ClimaInterpolations.Interpolation1D.Flat()`)."""
+    extrapolate::EX
+
+    """Source vertical levels whose size is `n_source_levels` x `n_columns`.
+    Empty when there is no vertical dimension."""
+    src_vertical_levels::SRC
+
+    """Vertical levels of the target space. Empty when there is no vertical
+    dimension."""
+    target_vertical_levels::TARGET
+
+    """Whether the data passed to `regrid` must be reversed along the vertical
+    dimension to match the direction of `src_vertical_levels`."""
+    flip_data::Bool
+
+    """Whether the target vertical levels are stored in increasing
+    order."""
+    is_target_vertical_levels_increasing::Bool
+
+    """Scratch space used in `regrid`."""
+    scratch_data::SCR
+end
+
+"""
+    _check_strictly_monotonic(levels, src_or_target::String)
+
+Check that each column of `levels` is strictly increasing or strictly
+decreasing, with the same direction for every column, and return whether the
+levels are increasing.
+
+Repeated levels are not allowed, as they break the vertical interpolation. The
+argument `src_or_target` (e.g. "source" or "target") is used in the error
+messages.
+"""
+function _check_strictly_monotonic(levels, src_or_target::String)
+    # Move to CPU since issorted can sometimes use scalar indexing
+    levels = Array(levels)
+    is_increasing = true
+    for (i, c) in enumerate(axes(levels, 2))
+        col = view(levels, :, c)
+        col_increasing = issorted(col; lt = <=)
+        col_decreasing = issorted(col; rev = true, lt = <=)
+        col_increasing ||
+            col_decreasing ||
+            error(
+                "The $src_or_target vertical levels of column $c are neither strictly increasing nor strictly decreasing",
+            )
+        if isone(i)
+            is_increasing = col_increasing
+        elseif is_increasing != col_increasing
+            error(
+                "The $src_or_target vertical levels have inconsistent directions across columns (some increasing, some decreasing)",
+            )
+        end
+    end
+    return is_increasing
+end
+
+"""
+    ColumnRegridder(target_space::ClimaCore.Spaces.AbstractSpace,
+                    src_vertical_levels = nothing;
+                    order = ClimaInterpolations.Interpolation1D.Linear(),
+                    extrapolate = ClimaInterpolations.Interpolation1D.Flat())
+
+Create a `ColumnRegridder` that interpolates data on the source vertical levels
+onto the vertical levels of `target_space`.
+
+The levels of each column in `src_vertical_levels` must be strictly increasing
+or strictly decreasing, with the same direction for every column. If `nothing`
+or an empty array is passed to `src_vertical_levels`, then a regridder that
+copies per-column values without vertical interpolation (e.g. for surface data)
+is used.
+
+Keyword arguments
+=================
+
+- `order`: the `ClimaInterpolations` interpolation order (e.g.
+  `ClimaInterpolations.Interpolation1D.Linear()`).
+- `extrapolate`: the `ClimaInterpolations` extrapolation conditions (e.g.
+  `ClimaInterpolations.Interpolation1D.Flat()`).
+"""
+function Regridders.ColumnRegridder(
+    target_space::Union{
+        ClimaCore.Spaces.FiniteDifferenceSpace,
+        ClimaCore.Spaces.MultiColumnFiniteDifferenceSpace,
+        ClimaCore.Spaces.PointSpace,
+        ClimaCore.Spaces.PointCloudSpace,
+    },
+    src_vertical_levels = nothing;
+    order = ClimaInterpolations.Interpolation1D.Linear(),
+    extrapolate = ClimaInterpolations.Interpolation1D.Flat(),
+)
+    FT = ClimaCore.Spaces.undertype(target_space)
+    AT = ClimaComms.array_type(target_space)
+
+    if isnothing(src_vertical_levels) || isempty(src_vertical_levels)
+        empty_levels = Matrix{FT}(undef, 0, 0)
+        return ColumnRegridder(
+            target_space,
+            order,
+            extrapolate,
+            empty_levels,
+            empty_levels,
+            false,
+            true,
+            nothing,
+        )
+    end
+
+    target_space isa Union{
+        ClimaCore.Spaces.FiniteDifferenceSpace,
+        ClimaCore.Spaces.MultiColumnFiniteDifferenceSpace,
+    } || error(
+        "Cannot regrid onto the target space: $(nameof(typeof(target_space)))",
+    )
+
+    # FT.(...) materializes the lazy array returned by field2array into a
+    # dense array, which interpolate1d! needs to dispatch to its GPU kernel
+    target_vertical_levels = FT.(
+        ClimaCore.Fields.field2array(
+            ClimaCore.Fields.coordinate_field(target_space).z,
+        )
+    )
+
+    num_src_cols = size(src_vertical_levels, 2)
+    num_target_cols = size(target_vertical_levels, 2)
+    num_src_cols == num_target_cols || error(
+        "The source vertical levels have $num_src_cols columns, but the target space has $num_target_cols columns",
+    )
+
+    # Check the vertical levels are strictly increasing or decreasing
+    is_target_increasing =
+        _check_strictly_monotonic(target_vertical_levels, "target")
+    is_src_increasing = _check_strictly_monotonic(src_vertical_levels, "source")
+
+    # Store the source levels in the same vertical direction as the
+    # target levels
+    # ClimaInterpolations expect either the source and target vertical
+    # levels to be strictly increasing or decreasing
+    flip_data = is_src_increasing != is_target_increasing
+    src_vertical_levels = FT.(src_vertical_levels)
+    flip_data && reverse!(src_vertical_levels, dims = 1)
+
+    src_vertical_levels = AT(src_vertical_levels)
+    return ColumnRegridder(
+        target_space,
+        order,
+        extrapolate,
+        src_vertical_levels,
+        target_vertical_levels,
+        flip_data,
+        is_target_increasing,
+        similar(src_vertical_levels),
+    )
+end
+
+"""
+    regrid(regridder::ColumnRegridder, data)
+
+Interpolate `data` on the regridder's source vertical levels onto the
+vertical levels of `regridder.target_space`, returning a
+`ClimaCore.Fields.Field`.
+
+The argument `data` is an array with size `n_source_levels` x `n_columns`.
+
+If there is no vertical dimension, the per-column values are copied into the
+field without interpolation.
+"""
+function Regridders.regrid(regridder::ColumnRegridder, data)
+    AT = ClimaComms.array_type(regridder.target_space)
+
+    field = zeros(regridder.target_space)
+    target_array = ClimaCore.Fields.field2array(field)
+
+    # This can happen with surface data (e.g. LAI data in ClimaLand)
+    if isempty(regridder.src_vertical_levels)
+        copyto!(target_array, vec(data))
+        return field
+    end
+
+    size(data) == size(regridder.src_vertical_levels) || error(
+        "The size of the data $(size(data)) does not match the size of the source vertical levels $(size(regridder.src_vertical_levels))",
+    )
+
+    # `interpolate1d!` requires all arrays to share the same element type
+    copyto!(regridder.scratch_data, data)
+    regridder.flip_data && reverse!(regridder.scratch_data, dims = 1)
+
+    ClimaInterpolations.Interpolation1D.interpolate1d!(
+        target_array,
+        regridder.src_vertical_levels,
+        regridder.target_vertical_levels,
+        regridder.scratch_data,
+        regridder.order,
+        regridder.extrapolate;
+        reverse = !regridder.is_target_vertical_levels_increasing,
+    )
+    return field
+end
+
+end

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -6,14 +6,32 @@ import Dates: Second
 import ClimaCore
 import ClimaCore: ClimaComms
 
+import NCDatasets
+
 import ClimaUtilities.DataStructures
 import ClimaUtilities.Regridders
-import ClimaUtilities.FileReaders: AbstractFileReader, NCFileReader, read, read!
+import ClimaUtilities.FileReaders:
+    AbstractFileReader, NCFileReader, MultiColumnNCFileReader, read, read!
 import ClimaUtilities.Regridders: AbstractRegridder, regrid
 
 import ClimaUtilities.Utils: isequispaced, period_to_seconds_float
 
 import ClimaUtilities.DataHandling
+
+"""
+    AbstractDataHandler
+
+Defines how to handle data from datasets and spatially interpolate them to
+`ClimaCore.Fields.Field`. Structs of this type do not interpolate temporally.
+
+The methods that only do time bookkeeping (`available_times`, `available_dates`,
+`previous_time`, `next_time`, `previous_date`, `next_date`, `dt`, `time_to_date`,
+`date_to_time`, and `close`) are implemented once on this abstract type and access the
+fields of the handler directly. Hence, every struct of this type must implement
+`regridded_snapshot(dh::YourDataHandler, date::Dates.DateTime)` and have the fields
+`file_readers`, `available_times`, `available_dates`, and `start_date`.
+"""
+abstract type AbstractDataHandler end
 
 """
     DataHandler{
@@ -58,7 +76,7 @@ struct DataHandler{
     FUNC <: Function,
     NAMES <: AbstractArray{<:AbstractString},
     PR <: AbstractDict{<:AbstractString, <:AbstractArray},
-}
+} <: AbstractDataHandler
     """Dictionary of variable names and objects responsible for getting the input data from disk to memory"""
     file_readers::FR
 
@@ -391,42 +409,42 @@ function DataHandling.DataHandler(
 end
 
 """
-    close(data_handler::DataHandler)
+    close(data_handler::AbstractDataHandler)
 
 Close all files associated to the given `data_handler`.
 """
-function Base.close(data_handler::DataHandler)
+function Base.close(data_handler::AbstractDataHandler)
     foreach(close, values(data_handler.file_readers))
     return nothing
 end
 
 """
-    available_times(data_handler::DataHandler)
+    available_times(data_handler::AbstractDataHandler)
 
 Return the time in seconds of the snapshots in the data, measured considering
 the starting time of the simulation and the reference date
 """
-function DataHandling.available_times(data_handler::DataHandler)
+function DataHandling.available_times(data_handler::AbstractDataHandler)
     return data_handler.available_times
 end
 
 """
-    available_dates(data_handler::DataHandler)
+    available_dates(data_handler::AbstractDataHandler)
 
 Return the dates of the snapshots in the data.
 """
-function DataHandling.available_dates(data_handler::DataHandler)
+function DataHandling.available_dates(data_handler::AbstractDataHandler)
     return data_handler.available_dates
 end
 
 """
-    dt(data_handler::DataHandler)
+    dt(data_handler::AbstractDataHandler)
 
 Return the time interval between data points for the data in `data_handler`.
 
 This requires the data to be defined on a equispaced temporal mesh.
 """
-function DataHandling.dt(data_handler::DataHandler)
+function DataHandling.dt(data_handler::AbstractDataHandler)
     isequispaced(DataHandling.available_times(data_handler)) ||
         error("dt not defined for non equispaced data")
     return DataHandling.available_times(data_handler)[begin + 1] -
@@ -435,7 +453,7 @@ end
 
 
 """
-    time_to_date(data_handler::DataHandler, time::AbstractFloat)
+    time_to_date(data_handler::AbstractDataHandler, time::AbstractFloat)
 
 Convert the given time to a calendar date.
 
@@ -444,7 +462,7 @@ date = start_date + time
 ```
 """
 function DataHandling.time_to_date(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     time::AbstractFloat,
 )
     # We go through milliseconds to allow fractions of a second (otherwise, Second(0.8)
@@ -457,7 +475,7 @@ function DataHandling.time_to_date(
 end
 
 """
-    date_to_time(data_handler::DataHandler, time::AbstractFloat)
+    date_to_time(data_handler::AbstractDataHandler, time::AbstractFloat)
 
 Convert the given calendar date to a time (in seconds).
 
@@ -466,15 +484,15 @@ date = start_date + time
 ```
 """
 function DataHandling.date_to_time(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     date::Dates.DateTime,
 )
     return period_to_seconds_float(date - data_handler.start_date)
 end
 
 """
-    previous_time(data_handler::DataHandler, time::AbstractFloat)
-    previous_time(data_handler::DataHandler, date::Dates.DateTime)
+    previous_time(data_handler::AbstractDataHandler, time::AbstractFloat)
+    previous_time(data_handler::AbstractDataHandler, date::Dates.DateTime)
 
 Return the time in seconds of the snapshot before the given `time`.
 If `time` is one of the snapshots, return itself.
@@ -482,7 +500,7 @@ If `time` is one of the snapshots, return itself.
 If `time` is not in the `data_handler`, return an error.
 """
 function DataHandling.previous_time(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     time::AbstractFloat,
 )
     date = DataHandling.time_to_date(data_handler, time)
@@ -490,7 +508,7 @@ function DataHandling.previous_time(
 end
 
 function DataHandling.previous_time(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     date::Dates.DateTime,
 )
     # We have to handle separately what happens when we are on the node
@@ -504,20 +522,26 @@ function DataHandling.previous_time(
 end
 
 """
-    next_time(data_handler::DataHandler, time::AbstractFloat)
-    next_time(data_handler::DataHandler, date::Dates.DateTime)
+    next_time(data_handler::AbstractDataHandler, time::AbstractFloat)
+    next_time(data_handler::AbstractDataHandler, date::Dates.DateTime)
 
 Return the time in seconds of the snapshot after the given `time`.
 If `time` is one of the snapshots, return the next time.
 
 If `time` is not in the `data_handler`, return an error.
 """
-function DataHandling.next_time(data_handler::DataHandler, time::AbstractFloat)
+function DataHandling.next_time(
+    data_handler::AbstractDataHandler,
+    time::AbstractFloat,
+)
     date = DataHandling.time_to_date(data_handler, time)
     return DataHandling.next_time(data_handler, date)
 end
 
-function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
+function DataHandling.next_time(
+    data_handler::AbstractDataHandler,
+    date::Dates.DateTime,
+)
     # We have to handle separately what happens when we are on the node
     if date in data_handler.available_dates
         index = searchsortedfirst(data_handler.available_dates, date) + 1
@@ -530,7 +554,7 @@ function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
 end
 
 """
-    DataHandling.previous_date(data_handler::DataHandler, time::Dates.TimeType)
+    DataHandling.previous_date(data_handler::AbstractDataHandler, time::Dates.TimeType)
 
 Return the date of the snapshot before the given `date`.
 If `date` is one of the snapshots, return itself.
@@ -538,7 +562,7 @@ If `date` is one of the snapshots, return itself.
 If `date` is not in the `data_handler`, return an error.
 """
 function DataHandling.previous_date(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     date::Dates.TimeType,
 )
     if date in data_handler.available_dates
@@ -551,14 +575,17 @@ function DataHandling.previous_date(
 end
 
 """
-    DataHandling.next_date(data_handler::DataHandler, time::Dates.TimeType)
+    DataHandling.next_date(data_handler::AbstractDataHandler, time::Dates.TimeType)
 
 Return the date of the snapshot after the given `time`.
 If `date` is one of the snapshots, return itself.
 
 If `date` is not in the `data_handler`, return an error.
 """
-function DataHandling.next_date(data_handler::DataHandler, date::Dates.TimeType)
+function DataHandling.next_date(
+    data_handler::AbstractDataHandler,
+    date::Dates.TimeType,
+)
     if date in data_handler.available_dates
         index = searchsortedfirst(data_handler.available_dates, date) + 1
     else
@@ -570,9 +597,9 @@ function DataHandling.next_date(data_handler::DataHandler, date::Dates.TimeType)
 end
 
 """
-    regridded_snapshot(data_handler::DataHandler, date::Dates.DateTime)
-    regridded_snapshot(data_handler::DataHandler, time::AbstractFloat)
-    regridded_snapshot(data_handler::DataHandler)
+    regridded_snapshot(data_handler::AbstractDataHandler, date::Dates.DateTime)
+    regridded_snapshot(data_handler::AbstractDataHandler, time::AbstractFloat)
+    regridded_snapshot(data_handler::AbstractDataHandler)
 
 Return the regridded snapshot from `data_handler` associated to the given `time` (if relevant).
 
@@ -636,14 +663,14 @@ function DataHandling.regridded_snapshot(
 end
 
 function DataHandling.regridded_snapshot(
-    data_handler::DataHandler,
+    data_handler::AbstractDataHandler,
     time::AbstractFloat,
 )
     date = DataHandling.time_to_date(data_handler, time)
     return DataHandling.regridded_snapshot(data_handler, date)
 end
 
-function DataHandling.regridded_snapshot(data_handler::DataHandler)
+function DataHandling.regridded_snapshot(data_handler::AbstractDataHandler)
     # This function can be called only when there are no dates (ie, the dataset is static)
     isempty(data_handler.available_dates) ||
         error("DataHandler is function of time")
@@ -665,6 +692,351 @@ expensive operation.
 function DataHandling.regridded_snapshot!(dest, data_handler, time)
     dest .= DataHandling.regridded_snapshot(data_handler, time)
     return nothing
+end
+
+
+"""
+    MultiColumnDataHandler
+
+A data handler that reads and remaps data column-by-column onto a multi-column
+space. Mirrors `DataHandler`, but keeps the horizontal and vertical dimensions
+separate (there is no horizontal interpolation; only the vertical is regridded).
+"""
+struct MultiColumnDataHandler{
+    FR <: AbstractDict{<:AbstractString, <:AbstractFileReader},
+    REG <: AbstractRegridder,
+    SPACE <: ClimaCore.Spaces.AbstractSpace,
+    HDIMS,
+    VDIM,
+    DATES <: AbstractArray{Dates.DateTime},
+    TIMES <: AbstractArray{<:AbstractFloat},
+    CACHE <: DataStructures.LRUCache{Dates.DateTime, ClimaCore.Fields.Field},
+    FUNC <: Function,
+    NAMES <: AbstractArray{<:AbstractString},
+    PR <: AbstractDict{<:AbstractString, <:AbstractArray},
+} <: AbstractDataHandler
+    """Dictionary of variable names and objects responsible for getting the input data from disk to memory"""
+    file_readers::FR
+
+    """Object responsible for resampling the column data to the simulation grid"""
+    regridder::REG
+
+    """ClimaCore Space over which the data has to be resampled"""
+    target_space::SPACE
+
+    """Tuple of per-column horizontal coordinates (e.g., (lons, lats))"""
+    horizontal_dimensions::HDIMS
+
+    """Per-column vertical levels (e.g., zs), empty when there is no z dimension"""
+    vertical_dimension::VDIM
+
+    """Calendar dates over which the data is defined"""
+    available_dates::DATES
+
+    """Reference calendar date at the beginning of the simulation."""
+    start_date::Dates.DateTime
+
+    """Timesteps over which the data is defined (in seconds)"""
+    available_times::TIMES
+
+    """Private field where cached regridded fields are stored"""
+    _cached_regridded_fields::CACHE
+
+    """Function to combine multiple input variables into a single data variable"""
+    compose_function::FUNC
+
+    """Names of the datasets in the NetCDF that have to be read and processed"""
+    varnames::NAMES
+
+    """Preallocated memory for storing read dataset"""
+    preallocated_read_data::PR
+end
+
+"""
+    MultiColumnDataHandler(dataset_sources,
+                           target_space::ClimaCore.Spaces.AbstractSpace;
+                           start_date::Union{Dates.DateTime, Dates.Date} = Dates.DateTime(1979, 1, 1),
+                           cache_max_size::Int = 2,
+                           compose_function = identity,
+                           file_reader_kwargs = (),
+                           regridder_kwargs = (),
+                           atol = 1e-3)
+
+Create a `MultiColumnDataHandler` from `dataset_sources` and remap them onto
+`target_space` column-by-column.
+
+Creating this object results in the files being accessed (to preallocate some memory).
+
+Within each variable, only the dates common to all of that variable's columns
+are considered (their intersection). Across variables, the available dates must
+be identical.
+
+Positional arguments
+=====================
+
+- `dataset_sources`: a vector of vectors of `DataSource`, where the outer vector
+  represents the variable and each inner vector represent that variable's
+  columns. A single `DataSource` or a vector of `DataSource` is also accepted
+  and treated as one variable. Each variable's columns are matched to
+  `target_space` by location. Columns not needed by the target space are
+  ignored.
+- `target_space`: the `ClimaCore` space to remap onto. Its horizontal space must be a
+  `PointCloudSpace`.
+
+Keyword arguments
+=================
+
+- `start_date`: reference date for the numeric time axis.
+- `cache_max_size`: size of the LRU cache of regridded `Field`s.
+- `compose_function`: combine multiple input variables into one (required when
+  there is more than one variable). The ordering of `dataset_sources` determines
+  the ordering of the arguments to the `compose_function`.
+- `file_reader_kwargs`: forwarded to each `MultiColumnNCFileReader`.
+- `regridder_kwargs`: forwarded to the `ColumnRegridder` constructor (e.g.
+  `order` or `extrapolate`).
+- `atol`: absolute tolerance (in degrees) used to match each column's
+  (lon, lat) location to the columns of `target_space`.
+"""
+function DataHandling.MultiColumnDataHandler(
+    dataset_sources,
+    target_space::ClimaCore.Spaces.AbstractSpace;
+    start_date::Union{Dates.DateTime, Dates.Date} = Dates.DateTime(1979, 1, 1),
+    cache_max_size::Int = 2,
+    compose_function = identity,
+    file_reader_kwargs = (),
+    regridder_kwargs = (),
+    atol = 1e-3,
+)
+    is_point_cloud(target_space) || error(
+        "There is only support for spaces whose horizontal space is a PointCloudSpace",
+    )
+
+    # Standardize to a vector of vectors, where the outer vector represents the
+    # variables and the inner vectors represent each variable's columns. There
+    # are three cases:
+    # 1. A single DataSource: one variable with a single column
+    # 2. A vector of DataSource: one variable with one or more columns
+    # 3. A vector of vector of DataSource: multiple variables, each with one
+    #    or more columns
+    is_vector = x -> x isa AbstractVector
+    is_vector(dataset_sources) || (dataset_sources = [dataset_sources])
+    isempty(dataset_sources) &&
+        error("At least one DataSource must be provided")
+    if !any(is_vector, dataset_sources)
+        # A vector of DataSource: a single variable
+        dataset_sources = [dataset_sources]
+    elseif !all(is_vector, dataset_sources)
+        error(
+            "For dataset_sources, pass a DataSource, a vector of DataSources, or a vector of vectors of DataSources",
+        )
+    end
+    any(isempty, dataset_sources) &&
+        error("Each variable must have at least one column")
+    any(col -> any(is_vector, col), dataset_sources) && error(
+        "Each inner vector of dataset_sources must contain only DataSources",
+    )
+
+    if length(dataset_sources) > 1 && compose_function == identity
+        error(
+            "`compose_function` must be specified when using multiple input variables",
+        )
+    end
+
+    # We can rely on MultiColumnNCFileReader to check that the variable name is
+    # consistent between the datasets
+    readers = map(dataset_sources) do column_sources
+        MultiColumnNCFileReader(
+            _find_columns_for_space(column_sources, target_space; atol);
+            file_reader_kwargs...,
+        )
+    end
+    varnames = [reader.varname for reader in readers]
+    allunique(varnames) || error(
+        "Duplicate variable names across dataset_sources ($varnames); each variable must have a unique name",
+    )
+    file_readers = Dict(zip(varnames, readers))
+
+    # The horizontal dimensions are already verified by constructing the file
+    # readers, so we check that the vertical levels agree between the different
+    # variables
+    ref_vertical = first(values(file_readers)).vertical_dimension
+    all(
+        file_reader ->
+            size(file_reader.vertical_dimension) == size(ref_vertical) &&
+            isapprox(file_reader.vertical_dimension, ref_vertical),
+        values(file_readers),
+    ) || error("Variables have inconsistent vertical dimensions")
+
+    # Dates carry no roundoff, so require them to match exactly across variables
+    allequal(
+        file_reader.available_dates for file_reader in values(file_readers)
+    ) || error("Variables have inconsistent available dates")
+
+    # Get all the relevant fields for the struct
+    file_reader = first(values(file_readers))
+    available_dates = file_reader.available_dates
+    available_times =
+        period_to_seconds_float.(available_dates .- Dates.DateTime(start_date))
+    horizontal_dimensions = file_reader.horizontal_dimensions
+    vertical_dimension = file_reader.vertical_dimension
+
+    # The regridder stores the source vertical levels and validates them
+    # (strictly increasing or decreasing, consistent direction across columns)
+    regridder = Regridders.ColumnRegridder(
+        target_space,
+        vertical_dimension;
+        regridder_kwargs...,
+    )
+
+    # Use LRU cache to store regridded fields
+    _cached_regridded_fields =
+        DataStructures.LRUCache{Dates.DateTime, ClimaCore.Fields.Field}(
+            max_size = cache_max_size,
+        )
+
+    # Preallocate space for each variable to be read
+    maybe_first_date = isempty(available_dates) ? () : (first(available_dates),)
+    preallocated_read_data = Dict(
+        varname => read(file_readers[varname], maybe_first_date...) for
+        varname in varnames
+    )
+
+    return MultiColumnDataHandler(
+        file_readers,
+        regridder,
+        target_space,
+        horizontal_dimensions,
+        vertical_dimension,
+        available_dates,
+        Dates.DateTime(start_date),
+        available_times,
+        _cached_regridded_fields,
+        compose_function,
+        varnames,
+        preallocated_read_data,
+    )
+end
+
+"""
+    is_point_cloud(space::ClimaCore.Spaces.AbstractSpace)
+
+Return true if the horizontal part of the `space` is a `PointCloudSpace`.
+
+This is used in the constructor for a `MultiColumnDataHandler` since that struct
+currently only supports spaces whose horizontal spaces are
+`PointCloudSpace`.
+"""
+is_point_cloud(space::ClimaCore.Spaces.AbstractSpace) =
+    ClimaCore.Spaces.horizontal_space(space) isa
+    ClimaCore.Spaces.PointCloudSpace
+is_point_cloud(::ClimaCore.Spaces.PointCloudSpace) = true
+is_point_cloud(::ClimaCore.Spaces.AbstractPointSpace) = false
+
+"""
+    _find_columns_for_space(file_sources, target_space; atol = 1e-3)
+
+Return the columns corresponding to the datasets in `file_sources` where each
+column of `target_space` correspond to a dataset in `file_sources`.
+"""
+function _find_columns_for_space(file_sources, target_space; atol = 1e-3)
+    # For CLiMA, longitudes range from -180 to 180. For some external datasets,
+    # longitudes range from 0 to 360. Applying this function to longitudes
+    # ranging from -180 to 180 is a no-op, but to longitudes ranging from
+    # 0 to 360 shifts them to -180 to 180. Both the space and the file
+    # longitudes are wrapped so the two are compared in the same convention.
+    # This function is copied from ClimaAnalysis.shift_longitude
+    wrap_longitude(lon, lower_lon, upper_lon) =
+        (lon >= upper_lon) || (lon < lower_lon) ?
+        mod1(lon - lower_lon, upper_lon - lower_lon) + lower_lon : lon
+    wrap_longitude(lon) = wrap_longitude(lon, -180, 180)
+
+    # `field2array` either return an array of size Nz x Ncolumn or a vector of
+    # size Ncolumn
+    coords = ClimaCore.Fields.coordinate_field(target_space)
+    first_level(a) = ndims(a) == 1 ? a : a[1, :]
+    space_lons = wrap_longitude.(
+        first_level(Array(ClimaCore.Fields.field2array(coords.long))),
+    )
+    space_lats = first_level(Array(ClimaCore.Fields.field2array(coords.lat)))
+    n_space_cols = length(space_lats)
+
+    # Find the longitude and latitude of each column of the datasets
+    col_lons = zeros(length(file_sources))
+    col_lats = zeros(length(file_sources))
+    for (j, source) in enumerate(file_sources)
+        first_file = first(source.file_paths)
+        (
+            haskey(source.coord_names, :lon) &&
+            haskey(source.coord_names, :lat)
+        ) || error(
+            "No longitude/latitude variables identified in $first_file. Pass `coord_names` to DataSource or check that the dataset have a longitude and latitude coordinate",
+        )
+        col_lons[j], col_lats[j] = NCDatasets.NCDataset(first_file) do ds
+            lon_values = ds[source.coord_names.lon][:]
+            lat_values = ds[source.coord_names.lat][:]
+            (length(lon_values) == 1 && length(lat_values) == 1) || error(
+                "Expected a single (lon, lat) location in $first_file, found $(length(lon_values)) longitudes and $(length(lat_values)) latitudes; only single-column files are supported",
+            )
+            (wrap_longitude(only(lon_values)), only(lat_values))
+        end
+    end
+
+    targets = map(1:n_space_cols) do i
+        matches = findall(
+            j ->
+                isapprox(col_lons[j], space_lons[i]; atol) &&
+                isapprox(col_lats[j], space_lats[i]; atol),
+            eachindex(file_sources),
+        )
+        isempty(matches) && error(
+            "No column matches target space column $i at (lon, lat) = ($(space_lons[i]), $(space_lats[i]))",
+        )
+        length(matches) == 1 || error(
+            "Multiple columns ($matches) match target space column $i at (lon, lat) = ($(space_lons[i]), $(space_lats[i])); locations may be closer than `atol` = $atol",
+        )
+        only(matches)
+    end
+
+    return file_sources[targets]
+end
+
+"""
+    regridded_snapshot(data_handler::MultiColumnDataHandler, date::Dates.DateTime)
+    regridded_snapshot(data_handler::MultiColumnDataHandler, time::AbstractFloat)
+    regridded_snapshot(data_handler::MultiColumnDataHandler)
+
+Return the regridded snapshot associated to the given `time`/`date` (if relevant).
+"""
+function DataHandling.regridded_snapshot(
+    data_handler::MultiColumnDataHandler,
+    date::Dates.DateTime,
+)
+    varnames = data_handler.varnames
+    compose_function = data_handler.compose_function
+
+    # Dates.DateTime(0) is the cache key for static maps
+    if date != Dates.DateTime(0)
+        file_paths = data_handler.file_readers[first(varnames)].file_paths
+        date in data_handler.available_dates ||
+            error("Date $date not available in files $(file_paths)")
+    end
+
+    return get!(data_handler._cached_regridded_fields, date) do
+        for varname in varnames
+            read!(
+                data_handler.preallocated_read_data[varname],
+                data_handler.file_readers[varname],
+                date,
+            )
+        end
+        data_composed = compose_function(
+            (
+                data_handler.preallocated_read_data[varname] for
+                varname in varnames
+            )...,
+        )
+        regrid(data_handler.regridder, data_composed)
+    end
 end
 
 end

--- a/ext/DataSourceExt.jl
+++ b/ext/DataSourceExt.jl
@@ -1,0 +1,200 @@
+module DataSourceExt
+
+import ClimaUtilities.FileReaders
+
+import Dates
+import NCDatasets
+
+include("nc_common.jl")
+
+"""
+    DataSource
+
+A lightweight description of a variable in one or more datasets which includes
+the path(s) to its source(s), the variable name, and its time axis. A
+`DataSource` holds no data itself. It records what is needed to read the
+variable, and the sources are joined along the time dimension when several are
+given.
+"""
+struct DataSource{CN <: NamedTuple, DS_KWARGS <: Tuple}
+    """Path(s) to the variable's source data: a single path, or several paths
+    to be joined along the time dimension."""
+    file_paths::Vector{String}
+
+    """Name of the variable this source reads."""
+    varname::String
+
+    """Calendar dates available in the source(s). Empty when the variable has
+    no time dimension."""
+    available_dates::Vector{Dates.DateTime}
+
+    """Index of the time dimension within the variable's dimensions, or `-1`
+    when the variable has no time dimension."""
+    time_index::Int
+
+    """Names of the coordinate variables in the source(s) by type of
+    coordinates."""
+    coord_names::CN
+
+    """Keyword arguments forwarded when opening the datasets."""
+    dataset_kwargs::DS_KWARGS
+end
+
+"""
+    FileReaders.DataSource(
+        file_paths,
+        varname::String;
+        time_transform = identity,
+        coord_names = nothing,
+    )
+
+Create a `DataSource` from `file_paths` for the variable `varname`.
+
+The argument `file_paths` is a single path or a collection of paths. If multiple
+paths are specified, then the datasets are joined along the time dimension. The
+paths must be in chronological order, and the coordinate variables must hold
+the same values in every file.
+
+The keyword argument `time_transform` is applied element-wise to each available
+date and must return a `Dates.DateTime`. The keyword argument `time_transform`
+is ignored for dataset with no time dimension.
+
+The keyword argument `coord_names` names the coordinate variables in the dataset
+by type of coordinate, e.g. `(; lon = "lon", lat = "lat", z = "height")`. When
+`coord_names` is `nothing`, the coordinates are automatically detected.
+"""
+function FileReaders.DataSource(
+    file_paths,
+    varname::String;
+    time_transform = identity,
+    coord_names = nothing,
+)
+    file_paths isa String && (file_paths = [file_paths])
+
+    isempty(file_paths) &&
+        error("The argument file_paths must contain at least one path")
+
+    # Open dataset by itself or by concating the datasets along the time
+    # dimension
+    only_one_file = length(file_paths) == 1
+    dataset_kwargs = ()
+    is_time = x -> x in TIME_NAMES
+    if !only_one_file
+        # Identify the time dimension from the first file so NCDatasets can join
+        # the files along it.
+        NCDatasets.NCDataset(first(file_paths)) do first_dataset
+            time_dims = filter(is_time, NCDatasets.dimnames(first_dataset))
+            isempty(time_dims) && error(
+                "Multiple files given for datasets, but no temporal dimension found. Combining multiple files is only possible along the temporal dimension.",
+            )
+
+            # When loading multifile dataset using NCDatasets.jl, the NetCDF files are
+            # not kept open due to the common limitation of 1024 open files per user on
+            # Linux. However, for our use case, we will not reach this limit. Hence, we
+            # keep the files open with deferopen = false.
+            # See: https://github.com/JuliaGeo/NCDatasets.jl/issues/277
+            dataset_kwargs = (:aggdim => first(time_dims), :deferopen => false)
+        end
+    end
+
+    # Open a single path by itself and open multiple paths by aggregating along
+    # the time dimension
+    files = only_one_file ? first(file_paths) : file_paths
+    time_index, available_dates, coord_names =
+        NCDatasets.NCDataset(files; dataset_kwargs...) do dataset
+
+            # Check varname exists in the dataset
+            varname in keys(dataset) ||
+                error("$varname is not available in $file_paths")
+
+            # Find the (unique) time dimension of the variable, if any
+            time_index_vec =
+                findall(is_time, NCDatasets.dimnames(dataset[varname]))
+            if isempty(time_index_vec)
+                time_index = -1
+            elseif length(time_index_vec) == 1
+                time_index = only(time_index_vec)
+            else
+                error("Could not find (unique) time dimension")
+            end
+
+            available_dates =
+                time_index != -1 ?
+                time_transform.(read_available_dates(dataset)) :
+                Dates.DateTime[]
+
+            if !isempty(available_dates)
+                issorted(available_dates) ||
+                    error("Dates are not sorted in $file_paths")
+                allunique(available_dates) ||
+                    error("Dates are not unique in $file_paths")
+            end
+
+            return time_index,
+            available_dates,
+            _resolve_coord_names(coord_names, dataset, file_paths)
+        end
+
+    only_one_file || _check_consistent_coords(coord_names, file_paths)
+
+    return DataSource(
+        file_paths,
+        varname,
+        available_dates,
+        time_index,
+        coord_names,
+        dataset_kwargs,
+    )
+end
+
+"""
+    _resolve_coord_names(coord_names, dataset, file_paths)
+
+Return the coordinate names to store on a `DataSource` for `dataset`.
+"""
+function _resolve_coord_names(coord_names, dataset, file_paths)
+    isnothing(coord_names) && return detect_coord_names(dataset, file_paths)
+    coord_names isa NamedTuple || error(
+        "coord_names must be a NamedTuple, e.g. (; lon = \"lon\", lat = \"lat\", z = \"z\")",
+    )
+    unrecognized = setdiff(keys(coord_names), keys(COORD_NAMES))
+    isempty(unrecognized) || error(
+        "Unrecognized coordinate types ($(join(unrecognized, ", "))) in coord_names; the recognized coordinate types are $(join(keys(COORD_NAMES), ", "))",
+    )
+    for (coord_type, name) in pairs(coord_names)
+        haskey(dataset, name) ||
+            error("$name ($coord_type) is not available in $file_paths")
+    end
+    return map(String, coord_names)
+end
+
+"""
+    _check_consistent_coords(coord_names, file_paths)
+
+Check that each coordinate variable in `coord_names` holds the same values in
+every file of a multi-file dataset.
+"""
+function _check_consistent_coords(coord_names, file_paths)
+    isempty(coord_names) && return nothing
+    reference = NCDatasets.NCDataset(first(file_paths)) do dataset
+        map(name -> Array(dataset[name]), coord_names)
+    end
+    for path in file_paths[2:end]
+        NCDatasets.NCDataset(path) do dataset
+            for (coord_type, name) in pairs(coord_names)
+                haskey(dataset, name) ||
+                    error("$name ($coord_type) is not available in $path")
+                values = Array(dataset[name])
+                (
+                    size(values) == size(reference[coord_type]) &&
+                    isapprox(values, reference[coord_type])
+                ) || error(
+                    "$name in $path does not match its values in $(first(file_paths)); files joined along the time dimension must hold the same coordinate values",
+                )
+            end
+        end
+    end
+    return nothing
+end
+
+end

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -109,8 +109,7 @@ function FileReaders.NCFileReader(
         # first dataset. We need this to aggregate multiple datasets, if data is split across
         # multiple files
         NCDatasets.NCDataset(first(file_paths)) do first_dataset
-            is_time =
-                x -> x == "time" || x == "date" || x == "t" || x == "valid_time"
+            is_time = x -> x in TIME_NAMES
             time_dims = filter(is_time, NCDatasets.dimnames(first_dataset))
             if !isempty(time_dims)
                 # When loading multifile dataset using NCDatasets.jl, the NetCDF files are
@@ -154,8 +153,7 @@ function FileReaders.NCFileReader(
         dim_names = NCDatasets.dimnames(dataset[varname])
 
         if !isempty(available_dates)
-            is_time =
-                x -> x == "time" || x == "date" || x == "t" || x == "valid_time"
+            is_time = x -> x in TIME_NAMES
 
             time_index_vec = findall(is_time, dim_names)
             length(time_index_vec) == 1 ||

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -358,4 +358,419 @@ function FileReaders.read!(
     return nothing
 end
 
+"""
+    MultiColumnNCFileReader
+
+A struct to read and process NetCDF files for multiple columns.
+"""
+struct MultiColumnNCFileReader{
+    VSTR <: AbstractVector,
+    STR2 <: AbstractString,
+    HDIMS <: Tuple,
+    VDIM <: AbstractArray,
+    DATES <: AbstractArray{Dates.DateTime},
+    PCD <: AbstractVector{<:AbstractArray{Dates.DateTime}},
+    NC <: AbstractVector,
+    PREP <: Function,
+    CACHE <: DataStructures.LRUCache{Dates.DateTime, <:AbstractArray},
+    VEC <: AbstractVector{Int},
+} <: FileReaders.AbstractFileReader
+
+    """Path of the NetCDF file(s), one collection per column"""
+    file_paths::VSTR
+
+    """Name of the dataset in the NetCDF files"""
+    varname::STR2
+
+    """A tuple of arrays with the horizontal physical dimensions where the data is
+    defined (e.g., (lons, lats))"""
+    horizontal_dimensions::HDIMS
+
+    """An array of the vertical levels with size (Nz, Ncolumn). If there is no vertical
+    dimension, then this is an array of size (0, Ncolumn)."""
+    vertical_dimension::VDIM
+
+    """A vector of DateTime collecting all the available dates in the files"""
+    available_dates::DATES
+
+    """A vector containing vectors of dates for each column."""
+    per_column_dates::PCD
+
+    """NetCDF datasets opened by NCDataset, one per column. Don't forget to close the
+    reader!"""
+    datasets::NC
+
+    """Optional function that is applied to the read dataset. Useful to do unit-conversion
+    or remove NaNs. Not suitable for anything more complicated than that."""
+    preprocess_func::PREP
+
+    """A place where to store values that have been already read. Uses an LRU cache,
+    which contains a dictionary mapping dates to arrays, and has a fixed maximum size.
+    For static data sets, a sentinel data `DateTime(0)` is used as key."""
+    _cached_reads::CACHE
+
+    """Per-column index of the time dimension in the array (typically first). -1 for static
+    datasets"""
+    time_indices::VEC
+
+    """The tuple `(Nz, Ncolumn)` which is the size of the output array. Used by `read` to
+    allocate."""
+    output_size::NTuple{2, Int}
+end
+
+"""
+    _open_source_dataset(source)
+
+Open (or fetch from the `OPEN_NCFILES` cache) the NetCDF dataset for a single
+`DataSource`, registering the source's `varname` so the file is closed only
+once every reader using it is closed.
+"""
+function _open_source_dataset(source)
+    column_paths = source.file_paths
+    ncdataset_arg =
+        length(column_paths) == 1 ? first(column_paths) : column_paths
+    dataset, open_varnames = get!(OPEN_NCFILES, column_paths) do
+        (
+            NCDatasets.NCDataset(ncdataset_arg; source.dataset_kwargs...),
+            Dict{String, Int}(),
+        )
+    end
+    _register_file!(open_varnames, source.varname)
+    return dataset
+end
+
+"""
+    _stack_columns(columns, file_paths, quantity)
+
+Stack the per-column vectors in `columns` into an `(Nz, Ncolumn)` array.
+
+This errors when the columns do not have the same length and uses `quantity` to
+name the inconsistent quantity in the error message.
+"""
+function _stack_columns(columns, file_paths, quantity)
+    allequal(length.(columns)) || error(
+        "Columns have inconsistent $quantity; ragged columns are not supported. " *
+        join(
+            (
+                "$(first(fp)): $(length(c))" for
+                (fp, c) in zip(file_paths, columns)
+            ),
+            ", ",
+        ),
+    )
+    return stack(columns)
+end
+
+"""
+    _read_scalar_coord(dataset, name, file_paths)
+
+Read the single value of the coordinate variable `name` in `dataset`, erroring
+when the variable holds more than one value (`file_paths` is not a single
+column).
+"""
+function _read_scalar_coord(dataset, name, file_paths)
+    values = dataset[name][:]
+    length(values) == 1 || error(
+        "Expected a single $name value in $file_paths, found $(length(values)); each column must hold a single (lon, lat) location",
+    )
+    return only(values)
+end
+
+"""
+    FileReaders.MultiColumnNCFileReader(
+        sources;
+        preprocess_func = identity,
+        cache_max_size::Int = 128,
+    )
+
+Create a `MultiColumnNCFileReader` from `sources`, one column per `DataSource`.
+
+## Arguments
+
+`sources` is a single `DataSource` (one column) or a vector of `DataSource`
+(one per column). All sources must read the same variable.
+
+`preprocess_func` preprocesses the data before returning it. This is useful for
+handling `NaN`s or converting units.
+
+The `cache_max_size` is the size of the cache used to store data after loading
+it from the files.
+
+!!! note "Common times"
+    Only the times common to all columns in the datasets are considered.
+"""
+function FileReaders.MultiColumnNCFileReader(
+    sources;
+    preprocess_func = identity,
+    cache_max_size::Int = 128,
+)
+    sources = sources isa AbstractVector ? sources : [sources]
+    isempty(sources) && error("At least one DataSource must be provided")
+
+    # All data sources should have the same variable name
+    varname = first(sources).varname
+    all(source -> source.varname == varname, sources) || error(
+        "All sources must read the same variable, got $(unique(source.varname for source in sources))",
+    )
+
+    file_paths = [source.file_paths for source in sources]
+
+    opened_sources = []
+    try
+        datasets = map(sources) do source
+            dataset = _open_source_dataset(source)
+            push!(opened_sources, source)
+            dataset
+        end
+
+        # In the future, if we want to support x and y instead of lat and lon, we can add it
+        # here
+
+        # Per-column longitude, latitude, and z levels. Each column file is
+        # assumed to hold a single (lon, lat) location. The coordinate variable
+        # names are recorded on each DataSource (user-provided or detected at
+        # construction).
+        for source in sources
+            (
+                haskey(source.coord_names, :lon) &&
+                haskey(source.coord_names, :lat)
+            ) || error(
+                "No longitude/latitude variables identified in $(first(source.file_paths)) (searched $(COORD_NAMES.lon) and $(COORD_NAMES.lat)); pass `coord_names` to DataSource",
+            )
+        end
+        lons = [
+            _read_scalar_coord(
+                dataset,
+                source.coord_names.lon,
+                source.file_paths,
+            ) for (source, dataset) in zip(sources, datasets)
+        ]
+        lats = [
+            _read_scalar_coord(
+                dataset,
+                source.coord_names.lat,
+                source.file_paths,
+            ) for (source, dataset) in zip(sources, datasets)
+        ]
+
+        # Create an array of size (Nz, Ncolumn) where each column of the array
+        # is the vertical levels for that column. It is not necessarily true
+        # that the vertical levels are the same across columns.
+        z_columns = [
+            NCDatasets.nomissing(dataset[source.coord_names.z][:]) for
+            (source, dataset) in zip(sources, datasets) if
+            haskey(source.coord_names, :z)
+        ]
+        length(z_columns) == 0 ||
+            length(z_columns) == length(datasets) ||
+            error(
+                "Inconsistent vertical levels: $(length(z_columns)) of $(length(datasets)) columns have a vertical coordinate. Either all columns or no columns must have vertical levels.",
+            )
+        zs =
+            isempty(z_columns) ? Array{Float64}(undef, 0, length(datasets)) :
+            _stack_columns(z_columns, file_paths, "numbers of z levels")
+
+        # Per-column index of the time dimension. A column whose variable has no
+        # time dimension is "static" and gets the sentinel value of -1
+        time_indices = [source.time_index for source in sources]
+        per_column_dates = [source.available_dates for source in sources]
+
+        # All columns are static or time varying
+        is_static = all(==(-1), time_indices)
+        is_time_varying = all(!=(-1), time_indices)
+        is_static ||
+            is_time_varying ||
+            error("Some columns have a time dimension and some do not")
+
+        # Only the times common to all columns are considered. The result is
+        # sorted because intersect keeps the order of its first argument, which
+        # DataSource validated as sorted. Keep each column's own dates
+        # (`per_column_dates`) so reads can look up a date's position within a
+        # column without re-reading it from disk.
+        available_dates = reduce(intersect, per_column_dates)
+        is_time_varying &&
+            isempty(available_dates) &&
+            error("Columns are time-varying but share no common dates")
+
+        # Get the output size and element type. The output size and element type
+        # is used by read when initializing the array. Furthermore, the element
+        # type is used to provide a concrete type for the cache.
+        sample_per_column = map(datasets, time_indices) do dataset, time_index
+            var = dataset[varname]
+            if time_index == -1
+                preprocess_func.(var[:])
+            else
+                slicer = [
+                    i == time_index ? 1 : Colon() for
+                    i in 1:length(NCDatasets.dimnames(var))
+                ]
+                vec(preprocess_func.(var[slicer...]))
+            end
+        end
+        sample = _stack_columns(sample_per_column, file_paths, "data lengths")
+        output_size = size(sample)
+
+        _cached_reads = DataStructures.LRUCache{Dates.DateTime, typeof(sample)}(
+            max_size = cache_max_size,
+        )
+
+        return MultiColumnNCFileReader(
+            file_paths,
+            varname,
+            (lons, lats),
+            zs,
+            available_dates,
+            per_column_dates,
+            datasets,
+            preprocess_func,
+            _cached_reads,
+            time_indices,
+            output_size,
+        )
+    catch
+        foreach(
+            source -> _release_file(source.file_paths, varname),
+            opened_sources,
+        )
+        rethrow()
+    end
+end
+
+"""
+    close(file_reader::MultiColumnNCFileReader)
+
+Close `MultiColumnNCFileReader`. For each underlying file, if no other reader is using it,
+close the NetCDF dataset.
+"""
+function Base.close(file_reader::MultiColumnNCFileReader)
+    for column_paths in file_reader.file_paths
+        _release_file(column_paths, file_reader.varname)
+    end
+    return nothing
+end
+
+"""
+    _read_all_columns(file_reader::MultiColumnNCFileReader)
+
+Helper function to read in the columns of datasets in `file_reader`.
+
+This is only used when the columns do not vary in time.
+"""
+function _read_all_columns(file_reader::MultiColumnNCFileReader)
+    dest = valtype(file_reader._cached_reads)(undef, file_reader.output_size...)
+    for (j, dataset) in enumerate(file_reader.datasets)
+        # Each column is a single (lon, lat) point, so the data flattens to its
+        # `Nz`-long profile (or length 1 when there is no z).
+        raw = dataset[file_reader.varname][:]
+        @views dest[:, j] .= file_reader.preprocess_func.(raw)
+    end
+    return dest
+end
+
+"""
+    read(file_reader::MultiColumnNCFileReader, date::Dates.DateTime)
+
+Read and preprocess the data at the given `date` for every column, returning a array of size
+`(Nz, Ncolumn)` (`Nz` is the number of z levels, or 1 when there is no z).
+"""
+function FileReaders.read(
+    file_reader::MultiColumnNCFileReader,
+    date::Dates.DateTime,
+)
+    dest = valtype(file_reader._cached_reads)(undef, file_reader.output_size...)
+    FileReaders.read!(dest, file_reader, date)
+    return dest
+end
+
+"""
+    available_dates(file_reader::MultiColumnNCFileReader)
+
+Return the dates common across the columns.
+"""
+function FileReaders.available_dates(file_reader::MultiColumnNCFileReader)
+    return file_reader.available_dates
+end
+
+"""
+    read(file_reader::MultiColumnNCFileReader)
+
+Read and preprocess data (for static datasets) for every column.
+"""
+function FileReaders.read(file_reader::MultiColumnNCFileReader)
+    dest = valtype(file_reader._cached_reads)(undef, file_reader.output_size...)
+    FileReaders.read!(dest, file_reader)
+    return dest
+end
+
+"""
+    read!(dest, file_reader::MultiColumnNCFileReader)
+
+Read and preprocess data (for static datasets), saving the output to `dest`.
+"""
+function FileReaders.read!(dest, file_reader::MultiColumnNCFileReader)
+    isempty(file_reader.available_dates) ||
+        error("File contains temporal data, date required")
+
+    # When there are no dates, we use DateTime(0) as the cache key
+    dest .= get!(file_reader._cached_reads, Dates.DateTime(0)) do
+        _read_all_columns(file_reader)
+    end
+    return nothing
+end
+
+"""
+    read!(dest, file_reader::MultiColumnNCFileReader, date::Dates.DateTime)
+
+Read and preprocess the data at the given `date`, saving the output to `dest`.
+"""
+function FileReaders.read!(
+    dest,
+    file_reader::MultiColumnNCFileReader,
+    date::Dates.DateTime,
+)
+    # DateTime(0) is the sentinel value for static datasets
+    if date == Dates.DateTime(0)
+        dest .= get!(file_reader._cached_reads, date) do
+            _read_all_columns(file_reader)
+        end
+        return nothing
+    end
+
+    dest .= get!(file_reader._cached_reads, date) do
+        # Read each column's slice at `date` into a single preallocated
+        # `(Nz, Ncolumn)` array, one column at a time (instead of allocating a
+        # vector per column and stacking them).
+        read_data = valtype(file_reader._cached_reads)(
+            undef,
+            file_reader.output_size...,
+        )
+        for (j, (dataset, time_index, column_dates)) in enumerate(
+            zip(
+                file_reader.datasets,
+                file_reader.time_indices,
+                file_reader.per_column_dates,
+            ),
+        )
+            var = dataset[file_reader.varname]
+            # `available_dates` is the intersection across columns; the position of `date`
+            # within an individual column's time dimension can differ, so look it up in the
+            # time dimension of the column
+            index = searchsortedfirst(column_dates, date)
+            (index <= length(column_dates) && column_dates[index] == date) || error(
+                "Date $date is not available in column $j ($(first(file_reader.file_paths[j])))",
+            )
+            slicer = [
+                i == time_index ? index : Colon() for
+                i in 1:length(NCDatasets.dimnames(var))
+            ]
+            # Each column is a single (lon, lat) point, so the slice flattens to
+            # its `Nz`-long profile (or length 1 when there is no z).
+            raw = vec(var[slicer...])
+            @views read_data[:, j] .= file_reader.preprocess_func.(raw)
+        end
+        return read_data
+    end
+    return nothing
+end
+
 end

--- a/ext/SpaceVaryingInputsExt.jl
+++ b/ext/SpaceVaryingInputsExt.jl
@@ -125,7 +125,7 @@ function SpaceVaryingInputs.SpaceVaryingInput(
 end
 
 """
-    SpaceVaryingInput(data_handler::DataHandler)
+    SpaceVaryingInput(data_handler::AbstractDataHandler)
     SpaceVaryingInput(file_paths::Union{AbstractString, AbstractArray{String}},
                       varnames::Union{AbstractString, AbstractArray{String}},
                       target_space::Spaces.AbstractSpace;

--- a/ext/nc_common.jl
+++ b/ext/nc_common.jl
@@ -1,6 +1,13 @@
 # Names a temporal dimension might have in a NetCDF file
 const TIME_NAMES = ("time", "date", "t", "valid_time")
 
+# Names a coordinate variable might have in a NetCDF file
+const COORD_NAMES = (;
+    lon = ("longitude", "lon", "long"),
+    lat = ("latitude", "lat"),
+    z = ("z", "lev", "level", "height", "altitude"),
+)
+
 # For a single and multi-file dataset
 const NetCDFDataset =
     Union{NCDatasets.NCDataset, NCDatasets.CommonDataModel.MFDataset}
@@ -29,4 +36,24 @@ function read_available_dates(ds::NetCDFDataset)
     else
         return Dates.DateTime[]
     end
+end
+
+"""
+    detect_coord_names(ds::NetCDFDataset, file_paths)
+
+Identify the coordinate variables in `ds` by matching its variable names
+case-insensitively against the candidates in `COORD_NAMES` and return the result
+as a `NamedTuple`.
+"""
+function detect_coord_names(ds::NetCDFDataset, file_paths)
+    found = Pair{Symbol, String}[]
+    varnames = collect(keys(ds))
+    for (coord_type, candidates) in pairs(COORD_NAMES)
+        matches = filter(name -> lowercase(name) in candidates, varnames)
+        length(matches) > 1 && error(
+            "Found multiple $coord_type variables ($(join(matches, ", "))) in $file_paths; pass `coord_names` to disambiguate",
+        )
+        isempty(matches) || push!(found, coord_type => only(matches))
+    end
+    return NamedTuple(found)
 end

--- a/ext/nc_common.jl
+++ b/ext/nc_common.jl
@@ -1,3 +1,6 @@
+# Names a temporal dimension might have in a NetCDF file
+const TIME_NAMES = ("time", "date", "t", "valid_time")
+
 # For a single and multi-file dataset
 const NetCDFDataset =
     Union{NCDatasets.NCDataset, NCDatasets.CommonDataModel.MFDataset}
@@ -11,7 +14,9 @@ available, return an empty vector.
 """
 function read_available_dates(ds::NetCDFDataset)
     # Check for time dimensions in order of preference
-    for time_dim in ("time", "t", "valid_time")
+    for time_dim in TIME_NAMES
+        # "date" holds integer yyyymmdd values and is parsed separately below
+        time_dim == "date" && continue
         if time_dim in keys(ds.dim)
             # NCDatasets.jl uses CFTime.jl, which supports a time resolution of
             # an attosecond, whereas Dates.DateTime only supports a time

--- a/src/DataHandling.jl
+++ b/src/DataHandling.jl
@@ -44,6 +44,8 @@ import ClimaUtilities.Utils: is_pkg_loaded
 
 function DataHandler end
 
+function MultiColumnDataHandler end
+
 function available_times end
 
 function available_dates end
@@ -69,6 +71,7 @@ function date_to_time end
 extension_fns = [
     :ClimaCore => [
         :DataHandler,
+        :MultiColumnDataHandler,
         :available_times,
         :available_dates,
         :previous_time,
@@ -83,6 +86,7 @@ extension_fns = [
     ],
     :NCDatasets => [
         :DataHandler,
+        :MultiColumnDataHandler,
         :available_times,
         :available_dates,
         :previous_time,
@@ -108,7 +112,7 @@ function __init__()
                     print(io, "\nImport $pkg to enable `$(exc.f)`.";)
                 end
             end
-            if Symbol(exc.f) == :DataHandler
+            if Symbol(exc.f) in (:DataHandler, :MultiColumnDataHandler)
                 print(
                     io,
                     "\nYou might also need a regridder to use `$(exc.f)`.",

--- a/src/FileReaders.jl
+++ b/src/FileReaders.jl
@@ -16,6 +16,8 @@ abstract type AbstractFileReader end
 
 function NCFileReader end
 
+function DatasetSource end
+
 function read end
 
 function read! end
@@ -27,6 +29,8 @@ function close_all_ncfiles end
 extension_fns = [
     :NCDatasets => [
         :NCFileReader,
+        :MultiColumnNCFileReader,
+        :DataSource,
         :read,
         :read!,
         :available_dates,

--- a/src/FileReaders.jl
+++ b/src/FileReaders.jl
@@ -16,7 +16,9 @@ abstract type AbstractFileReader end
 
 function NCFileReader end
 
-function DatasetSource end
+function MultiColumnNCFileReader end
+
+function DataSource end
 
 function read end
 

--- a/src/Regridders.jl
+++ b/src/Regridders.jl
@@ -21,6 +21,8 @@ function TempestRegridder end
 
 function InterpolationsRegridder end
 
+function ColumnRegridder end
+
 function regrid end
 
 function regrid! end
@@ -61,6 +63,7 @@ extension_fns = [
     :ClimaCoreTempestRemap => [:TempestRegridder, :regrid],
     :ClimaCore => [:InterpolationsRegridder, :regrid],
     :Interpolations => [:InterpolationsRegridder, :regrid],
+    :ClimaInterpolations => [:ColumnRegridder, :regrid],
 ]
 
 function __init__()

--- a/test/TestTools.jl
+++ b/test/TestTools.jl
@@ -165,3 +165,42 @@ function make_z_only_space(FT; context = ClimaComms.context())
 
     return vert_center_space
 end
+
+function make_column_space(
+    FT;
+    context = ClimaComms.context(),
+    points = [ClimaCore.Geometry.LatLongPoint(FT(0), FT(0))],
+    z_elem = 10,
+    z_min = FT(0),
+    z_max = FT(1),
+    reverse_mode = false,
+)
+    # `reverse_mode` builds a mesh with descending faces so that the coordinate
+    # field's z-levels are stored in decreasing order (useful for exercising a
+    # target space with decreasing vertical levels). The default path is left
+    # untouched (it uses the space's `DefaultZMesh`).
+    extra = if reverse_mode
+        z_domain = ClimaCore.Domains.IntervalDomain(
+            ClimaCore.Geometry.ZPoint(FT(z_min)),
+            ClimaCore.Geometry.ZPoint(FT(z_max));
+            boundary_names = (:bottom, :top),
+        )
+        faces = [
+            ClimaCore.Geometry.ZPoint(FT(z)) for
+            z in range(FT(z_max), FT(z_min); length = z_elem + 1)
+        ]
+        (; z_mesh = ClimaCore.Meshes.IntervalMesh(z_domain, faces))
+    else
+        (;)
+    end
+    return CommonSpaces.PointColumnEnsembleSpace(
+        FT;
+        device = ClimaComms.device(context),
+        points,
+        z_elem,
+        z_min,
+        z_max,
+        extra...,
+        staggering = CommonSpaces.CellCenter(),
+    )
+end

--- a/test/data_handling.jl
+++ b/test/data_handling.jl
@@ -4,6 +4,7 @@ using Test
 
 import ClimaUtilities
 import ClimaUtilities.DataHandling
+import ClimaUtilities.FileReaders
 
 import ClimaCore
 import ClimaComms
@@ -539,4 +540,397 @@ end
         )
 
     end
+end
+
+# The MultiColumnDataHandler reads one column per file and remaps onto a
+# PointColumnEnsembleSpace with ColumnRegridder (vertical interpolation via
+# ClimaInterpolations). The source files' z levels are chosen to coincide with
+# the target space's z levels (a uniform [0.5, nz + 0.5] mesh has cell centers
+# 1, 2, ..., nz), so the vertical interpolation is the identity and the column
+# profile is reproduced.
+@testset "MultiColumnDataHandler, static" begin
+    for FT in (Float32, Float64)
+        long, lat = FT(20), FT(10)
+        profile = FT[10, 20, 30, 40]
+        nz = length(profile)
+        target_space = make_column_space(
+            FT;
+            context,
+            points = [ClimaCore.Geometry.LatLongPoint(lat, long)],
+            z_elem = nz,
+            z_min = FT(0.5),
+            z_max = FT(nz + 0.5),
+        )
+
+        PATH = joinpath(mktempdir(), "static_col.nc")
+        NCDataset(PATH, "c") do nc
+            defDim(nc, "z", nz)
+            defVar(nc, "longitude", long, ())
+            defVar(nc, "latitude", lat, ())
+            defVar(nc, "z", FT[1, 2, 3, 4], ("z",))
+            defVar(nc, "sp", profile, ("z",))
+        end
+
+        data_handler = DataHandling.MultiColumnDataHandler(
+            [FileReaders.DataSource(PATH, "sp")],
+            target_space,
+        )
+
+        @test DataHandling.available_dates(data_handler) == DateTime[]
+
+        field = DataHandling.regridded_snapshot(data_handler)
+        @test field isa ClimaCore.Fields.Field
+        @test axes(field) == target_space
+        @test eltype(field) == FT
+        # Source and target z coincide, so the profile is reproduced
+        @test vec(Array(ClimaCore.Fields.field2array(field))) ≈ profile
+
+        close(data_handler)
+    end
+
+    # Test with different coordinate names
+    FT = Float32
+    long, lat = FT(20), FT(10)
+    profile = FT[10, 20, 30, 40]
+    nz = length(profile)
+    target_space = make_column_space(
+        FT;
+        context,
+        points = [ClimaCore.Geometry.LatLongPoint(lat, long)],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+
+    PATH = joinpath(mktempdir(), "custom_names_col.nc")
+    NCDataset(PATH, "c") do nc
+        defDim(nc, "zed", nz)
+        defVar(nc, "x_lon", long, ())
+        defVar(nc, "y_lat", lat, ())
+        defVar(nc, "zed", FT[1, 2, 3, 4], ("zed",))
+        defVar(nc, "sp", profile, ("zed",))
+    end
+
+    source = FileReaders.DataSource(
+        PATH,
+        "sp";
+        coord_names = (; lon = "x_lon", lat = "y_lat", z = "zed"),
+    )
+    data_handler = DataHandling.MultiColumnDataHandler([source], target_space)
+
+    field = DataHandling.regridded_snapshot(data_handler)
+    @test vec(Array(ClimaCore.Fields.field2array(field))) ≈ profile
+
+    close(data_handler)
+end
+
+@testset "MultiColumnDataHandler, time data" begin
+    for FT in (Float32, Float64)
+        long, lat = FT(20), FT(10)
+        times =
+            [DateTime(2000, 1, 1), DateTime(2000, 1, 2), DateTime(2000, 1, 3)]
+        target_space = make_column_space(
+            FT;
+            context,
+            points = [ClimaCore.Geometry.LatLongPoint(lat, long)],
+            z_elem = 4,
+            z_min = FT(0.5),
+            z_max = FT(4.5),
+        )
+
+        PATH = joinpath(mktempdir(), "tv_col.nc")
+        NCDataset(PATH, "c") do nc
+            defDim(nc, "z", 4)
+            defDim(nc, "time", length(times))
+            defVar(nc, "longitude", long, ())
+            defVar(nc, "latitude", lat, ())
+            defVar(nc, "z", FT[1, 2, 3, 4], ("z",))
+            defVar(nc, "time", times, ("time",))
+            var = defVar(nc, "sp", FT, ("z", "time"))
+            # Profile of column at time t is [1, 2, 3, 4] * t
+            for t in eachindex(times)
+                var[:, t] = FT[1, 2, 3, 4] .* t
+            end
+        end
+
+        data_handler = DataHandling.MultiColumnDataHandler(
+            [FileReaders.DataSource(PATH, "sp")],
+            target_space;
+            start_date = DateTime(2000, 1, 1),
+        )
+
+        available_dates = DataHandling.available_dates(data_handler)
+        available_times = DataHandling.available_times(data_handler)
+        @test available_dates == times
+        @test data_handler.start_date .+ Second.(available_times) ==
+              available_dates
+
+        @test DataHandling.dt(data_handler) ==
+              available_times[2] - available_times[1]
+        @test DataHandling.time_to_date(data_handler, 0.0) ==
+              data_handler.start_date
+        @test DataHandling.date_to_time(
+            data_handler,
+            data_handler.start_date,
+        ) == 0.0
+
+        @test DataHandling.previous_date(
+            data_handler,
+            available_dates[2] + Second(1),
+        ) == available_dates[2]
+        @test DataHandling.next_date(
+            data_handler,
+            available_dates[1] + Second(1),
+        ) == available_dates[2]
+
+        # Source and target z coincide, so no interpolation is done
+        field =
+            DataHandling.regridded_snapshot(data_handler, available_times[2])
+        @test field isa ClimaCore.Fields.Field
+        @test axes(field) == target_space
+        @test eltype(field) == FT
+        @test vec(Array(ClimaCore.Fields.field2array(field))) ≈
+              FT[1, 2, 3, 4] .* 2
+
+        # In-place version of regridded_snapshot
+        dest = zeros(target_space)
+        DataHandling.regridded_snapshot!(dest, data_handler, available_times[2])
+        @test vec(Array(ClimaCore.Fields.field2array(dest))) ≈
+              FT[1, 2, 3, 4] .* 2
+
+        close(data_handler)
+    end
+end
+
+@testset "MultiColumnDataHandler, multiple variables and column ordering" begin
+    FT = Float64
+    lon1, lat1 = FT(20), FT(10)
+    lon2, lat2 = FT(40), FT(50)
+    nz = 4
+    target_space = make_column_space(
+        FT;
+        context,
+        points = [
+            ClimaCore.Geometry.LatLongPoint(lat1, lon1),
+            ClimaCore.Geometry.LatLongPoint(lat2, lon2),
+        ],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+
+    dir = mktempdir()
+    function write_col(name, varname, lon, lat, profile)
+        path = joinpath(dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", nz)
+            defVar(nc, "longitude", lon, ())
+            defVar(nc, "latitude", lat, ())
+            defVar(nc, "z", FT[1, 2, 3, 4], ("z",))
+            defVar(nc, varname, profile, ("z",))
+        end
+        return path
+    end
+
+    a1, a2 = FT[1, 1, 1, 1], FT[2, 2, 2, 2]
+    b1, b2 = FT[10, 10, 10, 10], FT[20, 20, 20, 20]
+
+    # Columns are provided out of the target space's order; the handler matches
+    # them to the space by location
+    a_sources = [
+        FileReaders.DataSource(write_col("a2.nc", "a", lon2, lat2, a2), "a"),
+        FileReaders.DataSource(write_col("a1.nc", "a", lon1, lat1, a1), "a"),
+    ]
+    b_sources = [
+        FileReaders.DataSource(write_col("b1.nc", "b", lon1, lat1, b1), "b"),
+        FileReaders.DataSource(write_col("b2.nc", "b", lon2, lat2, b2), "b"),
+    ]
+
+    # Use compose_function where argument order matters
+    data_handler = DataHandling.MultiColumnDataHandler(
+        [a_sources, b_sources],
+        target_space;
+        compose_function = (a, b) -> a .- 2 .* b,
+    )
+
+    @test data_handler.varnames == ["a", "b"]
+
+    field = DataHandling.regridded_snapshot(data_handler)
+    arr = Array(ClimaCore.Fields.field2array(field))
+    coords = ClimaCore.Fields.coordinate_field(target_space)
+    lons = Array(ClimaCore.Fields.field2array(coords.long))[1, :]
+    for c in axes(arr, 2)
+        expected = isapprox(lons[c], lon1) ? a1 .- 2 .* b1 : a2 .- 2 .* b2
+        @test arr[:, c] ≈ expected
+    end
+
+    close(data_handler)
+end
+
+@testset "MultiColumnDataHandler, column matching" begin
+    FT = Float32
+    nz = 4
+    zs = FT[1, 2, 3, 4]
+    dir = mktempdir()
+    function write_col(name, lon, lat, profile)
+        path = joinpath(dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", nz)
+            defVar(nc, "longitude", lon, ())
+            defVar(nc, "latitude", lat, ())
+            defVar(nc, "z", zs, ("z",))
+            defVar(nc, "sp", profile, ("z",))
+        end
+        return path
+    end
+
+    lon1, lat1 = FT(20), FT(10)
+    lon2, lat2 = FT(40), FT(50)
+    target_space = make_column_space(
+        FT;
+        context,
+        points = [
+            ClimaCore.Geometry.LatLongPoint(lat1, lon1),
+            ClimaCore.Geometry.LatLongPoint(lat2, lon2),
+        ],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+
+    # The sources do not cover every column of the target space
+    far_source = FileReaders.DataSource(
+        write_col("cm_far.nc", FT(100), FT(-60), zs),
+        "sp",
+    )
+    @test_throws contains("No column matches") DataHandling.MultiColumnDataHandler(
+        [far_source],
+        target_space,
+    )
+
+    # Two sources at locations closer than atol
+    near1 =
+        FileReaders.DataSource(write_col("cm_near1.nc", lon1, lat1, zs), "sp")
+    near2 = FileReaders.DataSource(
+        write_col("cm_near2.nc", lon1 + FT(1e-5), lat1, zs .+ 100),
+        "sp",
+    )
+    col2 = FileReaders.DataSource(write_col("cm_col2.nc", lon2, lat2, zs), "sp")
+    @test_throws contains("Multiple columns") DataHandling.MultiColumnDataHandler(
+        [near1, near2, col2],
+        target_space,
+    )
+
+    # Use smaller number for atol so near1 and col2 are matched with the columns
+    # in target_space
+    data_handler = DataHandling.MultiColumnDataHandler(
+        [near1, near2, col2],
+        target_space;
+        atol = 1e-7,
+    )
+    field = DataHandling.regridded_snapshot(data_handler)
+    arr = Array(ClimaCore.Fields.field2array(field))
+    for c in axes(arr, 2)
+        @test arr[:, c] ≈ zs
+    end
+    close(data_handler)
+
+    # Longitudes ranging from 0 to 360 degrees should map to -180 to 180 degrees
+    wrap_space = make_column_space(
+        FT;
+        context,
+        points = [ClimaCore.Geometry.LatLongPoint(lat1, FT(-20))],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+    wrapped = FileReaders.DataSource(
+        write_col("cm_wrap.nc", FT(340), lat1, FT[10, 20, 30, 40]),
+        "sp",
+    )
+    extra = FileReaders.DataSource(
+        write_col("cm_extra.nc", FT(100), FT(-60), zs),
+        "sp",
+    )
+    data_handler =
+        DataHandling.MultiColumnDataHandler([wrapped, extra], wrap_space)
+    field = DataHandling.regridded_snapshot(data_handler)
+    @test vec(Array(ClimaCore.Fields.field2array(field))) ≈ FT[10, 20, 30, 40]
+    close(data_handler)
+end
+
+@testset "MultiColumnDataHandler errors" begin
+    FT = Float32
+    long, lat = FT(20), FT(10)
+    nz = 4
+    target_space = make_column_space(
+        FT;
+        context,
+        points = [ClimaCore.Geometry.LatLongPoint(lat, long)],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+
+    dir = mktempdir()
+    function write_col(name, varname; zs = FT[1, 2, 3, 4])
+        path = joinpath(dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defVar(nc, "longitude", long, ())
+            defVar(nc, "latitude", lat, ())
+            defVar(nc, "z", zs, ("z",))
+            defVar(nc, varname, zs, ("z",))
+        end
+        return path
+    end
+
+    a_source = FileReaders.DataSource(write_col("err_a.nc", "a"), "a")
+    b_source = FileReaders.DataSource(write_col("err_b.nc", "b"), "b")
+
+    # The horizontal part of the target space must be a PointCloudSpace
+    spherical_space = make_spherical_space(FT).hybrid
+    @test_throws contains("PointCloudSpace") DataHandling.MultiColumnDataHandler(
+        [a_source],
+        spherical_space,
+    )
+
+    # No sources at all
+    @test_throws contains("At least one DataSource") DataHandling.MultiColumnDataHandler(
+        [],
+        target_space,
+    )
+
+    # A mix of DataSources and vectors of DataSources
+    @test_throws contains("pass a DataSource") DataHandling.MultiColumnDataHandler(
+        [a_source, [b_source]],
+        target_space,
+    )
+
+    # Multiple variables require a compose_function
+    @test_throws contains("compose_function") DataHandling.MultiColumnDataHandler(
+        [[a_source], [b_source]],
+        target_space,
+    )
+
+    # Duplicate variable names across dataset_sources
+    a2_source = FileReaders.DataSource(write_col("err_a2.nc", "a"), "a")
+    @test_throws contains("Duplicate variable names") DataHandling.MultiColumnDataHandler(
+        [[a_source], [a2_source]],
+        target_space;
+        compose_function = (x, y) -> x .+ y,
+    )
+
+    # Variables with different vertical levels
+    c_source = FileReaders.DataSource(
+        write_col("err_c.nc", "c"; zs = FT[1, 2, 3, 5]),
+        "c",
+    )
+    @test_throws contains("inconsistent vertical dimensions") DataHandling.MultiColumnDataHandler(
+        [[a_source], [c_source]],
+        target_space;
+        compose_function = (x, y) -> x .+ y,
+    )
+
+    FileReaders.close_all_ncfiles()
 end

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -376,3 +376,380 @@ end
         Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
     @test isempty(open_ncfiles)
 end
+
+@testset "MultiColumnNCFileReader without time" begin
+    # Each column lives in its own file with scalar longitude/latitude and its
+    # own z profile. Column i holds `[10i, 20i, 30i]` so we can predict the
+    # stacked output.
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+    lons, lats = [10.0, 40.0], [20.0, 50.0]
+    paths = map(eachindex(lons)) do i
+        path = joinpath(data_dir, "static_col_$i.nc")
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defVar(nc, "longitude", lons[i], ())
+            defVar(nc, "latitude", lats[i], ())
+            defVar(nc, "z", zs, ("z",))
+            defVar(nc, "myvar", Float64[10i, 20i, 30i], ("z",))
+        end
+        path
+    end
+
+    sources = [FileReaders.DataSource(path, "myvar") for path in paths]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+
+    @test ncreader.horizontal_dimensions == (lons, lats)
+    @test ncreader.vertical_dimension == [zs zs]  # (Nz, Ncolumn) array
+    @test isempty(FileReaders.available_dates(ncreader))
+
+    # Each column represents a single dataset
+    expected = [10.0 20.0; 20.0 40.0; 30.0 60.0]
+    @test FileReaders.read(ncreader) == expected
+
+    dest = zeros(size(expected))
+    FileReaders.read!(dest, ncreader)
+    @test dest == expected
+
+    open_ncfiles =
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
+    close(ncreader)
+    @test all(
+        file_path -> !haskey(open_ncfiles, file_path),
+        ncreader.file_paths,
+    )
+end
+
+@testset "MultiColumnNCFileReader coordinate names" begin
+    # Coordinate variable names are per column: one column uses names that are
+    # detected, the other declares its own via `coord_names`.
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+
+    detected_path = joinpath(data_dir, "cn_col_1.nc")
+    NCDataset(detected_path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defVar(nc, "lon", 10.0, ())
+        defVar(nc, "lat", 20.0, ())
+        defVar(nc, "z", zs, ("z",))
+        defVar(nc, "myvar", Float64[10, 20, 30], ("z",))
+    end
+
+    custom_path = joinpath(data_dir, "cn_col_2.nc")
+    NCDataset(custom_path, "c") do nc
+        defDim(nc, "zed", length(zs))
+        defVar(nc, "x_lon", 40.0, ())
+        defVar(nc, "y_lat", 50.0, ())
+        defVar(nc, "zed", zs, ("zed",))
+        defVar(nc, "myvar", Float64[20, 40, 60], ("zed",))
+    end
+
+    sources = [
+        FileReaders.DataSource(detected_path, "myvar"),
+        FileReaders.DataSource(
+            custom_path,
+            "myvar";
+            coord_names = (; lon = "x_lon", lat = "y_lat", z = "zed"),
+        ),
+    ]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+
+    @test ncreader.horizontal_dimensions == ([10.0, 40.0], [20.0, 50.0])
+    @test ncreader.vertical_dimension == [zs zs]
+    @test FileReaders.read(ncreader) == [10.0 20.0; 20.0 40.0; 30.0 60.0]
+
+    close(ncreader)
+end
+
+@testset "MultiColumnNCFileReader missing values" begin
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+
+    gap_path = joinpath(data_dir, "fill_gap.nc")
+    NCDataset(gap_path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defVar(nc, "longitude", 10.0, ())
+        defVar(nc, "latitude", 20.0, ())
+        defVar(nc, "z", zs, ("z",))
+        var = defVar(nc, "myvar", Float64, ("z",), fillvalue = -999.0)
+        var[:] = [1.0, missing, 3.0]
+    end
+    ncreader = FileReaders.MultiColumnNCFileReader(
+        FileReaders.DataSource(gap_path, "myvar");
+        preprocess_func = x -> coalesce(x, NaN),
+    )
+    data = FileReaders.read(ncreader)
+    @test data[1, 1] == 1.0
+    @test isnan(data[2, 1])
+    @test data[3, 1] == 3.0
+    close(ncreader)
+end
+
+@testset "MultiColumnNCFileReader with time" begin
+    open_ncfiles =
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
+
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+    lons, lats = [10.0, 40.0], [20.0, 50.0]
+    times = [DateTime(2000, 1, 1), DateTime(2000, 1, 2)]
+    paths = map(eachindex(lons)) do i
+        path = joinpath(data_dir, "tv_col_$i.nc")
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defDim(nc, "time", length(times))
+            defVar(nc, "longitude", lons[i], ())
+            defVar(nc, "latitude", lats[i], ())
+            defVar(nc, "z", zs, ("z",))
+            defVar(nc, "time", times, ("time",))
+            var = defVar(nc, "myvar", Float64, ("z", "time"))
+            for t in eachindex(times)
+                var[:, t] = Float64[i, 2i, 3i] .* t
+            end
+        end
+        path
+    end
+
+    # Single file
+    ncreader = FileReaders.MultiColumnNCFileReader(
+        FileReaders.DataSource(first(paths), "myvar"),
+    )
+    @test FileReaders.available_dates(ncreader) == times
+
+    # Reads
+    @test FileReaders.read(ncreader, times[2]) == [2.0; 4.0; 6.0;;]
+    dest = zeros(3, 1)
+    FileReaders.read!(dest, ncreader, times[1])
+    @test dest == [1.0; 2.0; 3.0;;]
+
+    close(ncreader)
+    @test all(cols -> !haskey(open_ncfiles, cols), ncreader.file_paths)
+
+    # Multiple columns, one file each
+    sources = [FileReaders.DataSource(path, "myvar") for path in paths]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+    @test FileReaders.available_dates(ncreader) == times
+
+    # Reads
+    @test FileReaders.read(ncreader, times[2]) == [2.0 4.0; 4.0 8.0; 6.0 12.0]
+    dest = zeros(3, 2)
+    FileReaders.read!(dest, ncreader, times[1])
+    @test dest == [1.0 2.0; 2.0 4.0; 3.0 6.0]
+
+    close(ncreader)
+    @test all(cols -> !haskey(open_ncfiles, cols), ncreader.file_paths)
+
+    # Vector of vectors of files: one inner vector per column, where each
+    # column's time steps are split across separate files that get joined along
+    # the time dimension.
+    split_paths = map(eachindex(lons)) do i
+        map(eachindex(times)) do t
+            path = joinpath(data_dir, "split_col_$(i)_t$(t).nc")
+            NCDataset(path, "c") do nc
+                defDim(nc, "z", length(zs))
+                defDim(nc, "time", 1)
+                defVar(nc, "longitude", lons[i], ())
+                defVar(nc, "latitude", lats[i], ())
+                defVar(nc, "z", zs, ("z",))
+                defVar(nc, "time", [times[t]], ("time",))
+                var = defVar(nc, "myvar", Float64, ("z", "time"))
+                var[:, 1] = Float64[i, 2i, 3i] .* t
+            end
+            path
+        end
+    end
+    @test split_paths isa AbstractVector{<:AbstractVector{<:AbstractString}}
+
+    sources = [
+        FileReaders.DataSource(col_paths, "myvar") for col_paths in split_paths
+    ]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+    @test FileReaders.available_dates(ncreader) == times
+
+    # Reads
+    @test FileReaders.read(ncreader, times[2]) == [2.0 4.0; 4.0 8.0; 6.0 12.0]
+    dest = zeros(3, 2)
+    FileReaders.read!(dest, ncreader, times[1])
+    @test dest == [1.0 2.0; 2.0 4.0; 3.0 6.0]
+
+    close(ncreader)
+    @test all(cols -> !haskey(open_ncfiles, cols), ncreader.file_paths)
+end
+
+@testset "MultiColumnNCFileReader static surface data (no z)" begin
+    # Surface columns: a scalar variable and no z dimension. The output is
+    # (1, Ncolumn)
+    data_dir = mktempdir()
+    lons, lats = [10.0, 40.0], [20.0, 50.0]
+    values = [5.0, 7.0]
+    paths = map(eachindex(lons)) do i
+        path = joinpath(data_dir, "surface_col_$i.nc")
+        NCDataset(path, "c") do nc
+            defVar(nc, "longitude", lons[i], ())
+            defVar(nc, "latitude", lats[i], ())
+            defVar(nc, "myvar", values[i], ())
+        end
+        path
+    end
+
+    sources = [FileReaders.DataSource(path, "myvar") for path in paths]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+
+    @test isempty(ncreader.vertical_dimension)
+    @test FileReaders.read(ncreader) == [5.0 7.0]
+    close(ncreader)
+end
+
+@testset "MultiColumnNCFileReader partially overlapping dates" begin
+    # The columns share only a subset of their dates: `available_dates` is the
+    # intersection, and a read at a common date must look the date up in each
+    # column's own time axis (the same date sits at a different index in each
+    # column).
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+    lons, lats = [10.0, 40.0], [20.0, 50.0]
+    all_times = [DateTime(2000, 1, d) for d in 1:4]
+    times_per_col = [all_times[1:3], all_times[2:4]]
+    paths = map(eachindex(lons)) do i
+        times = times_per_col[i]
+        path = joinpath(data_dir, "overlap_col_$i.nc")
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defDim(nc, "time", length(times))
+            defVar(nc, "longitude", lons[i], ())
+            defVar(nc, "latitude", lats[i], ())
+            defVar(nc, "z", zs, ("z",))
+            defVar(nc, "time", times, ("time",))
+            var = defVar(nc, "myvar", Float64, ("z", "time"))
+            # The value depends on the date rather than on the time index, so
+            # a read that confused a date's per-column index would be detected
+            for t in eachindex(times)
+                var[:, t] = i .* zs .* Dates.day(times[t])
+            end
+        end
+        path
+    end
+
+    sources = [FileReaders.DataSource(path, "myvar") for path in paths]
+    ncreader = FileReaders.MultiColumnNCFileReader(sources)
+
+    @test FileReaders.available_dates(ncreader) == all_times[2:3]
+
+    # DateTime(2000, 1, 2) is at index 2 in column 1 and index 1 in column 2
+    @test FileReaders.read(ncreader, all_times[2]) == [2 .* zs 4 .* zs]
+    @test FileReaders.read(ncreader, all_times[3]) == [3 .* zs 6 .* zs]
+
+    close(ncreader)
+end
+
+@testset "MultiColumnNCFileReader preprocessing data and time" begin
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+    times = [DateTime(2000, 1, 1), DateTime(2000, 1, 2)]
+    path = joinpath(data_dir, "tt_col.nc")
+    NCDataset(path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defDim(nc, "time", length(times))
+        defVar(nc, "longitude", 10.0, ())
+        defVar(nc, "latitude", 20.0, ())
+        defVar(nc, "z", zs, ("z",))
+        defVar(nc, "time", times, ("time",))
+        var = defVar(nc, "myvar", Float64, ("z", "time"))
+        for t in eachindex(times)
+            var[:, t] = zs .* t
+        end
+    end
+
+    shift = Day(1)
+    source =
+        FileReaders.DataSource(path, "myvar"; time_transform = d -> d + shift)
+    ncreader =
+        FileReaders.MultiColumnNCFileReader(source; preprocess_func = x -> 2x)
+
+    @test FileReaders.available_dates(ncreader) == times .+ shift
+    @test FileReaders.read(ncreader, times[2] + shift) == [4.0; 8.0; 12.0;;]
+    @test FileReaders.read(ncreader, times[1] + shift) == [2.0; 4.0; 6.0;;]
+
+    close(ncreader)
+end
+
+@testset "MultiColumnNCFileReader error handling" begin
+    open_ncfiles =
+        Base.get_extension(ClimaUtilities, :ClimaUtilitiesNCDatasetsExt).NCFileReaderExt.OPEN_NCFILES
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+
+    # Write one column file. `times === nothing` makes a static column (no time
+    # dimension); otherwise the file is time-varying with the given time axis.
+    function make_col(name, times)
+        path = joinpath(data_dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defVar(nc, "longitude", 10.0, ())
+            defVar(nc, "latitude", 20.0, ())
+            defVar(nc, "z", zs, ("z",))
+            if isnothing(times)
+                defVar(nc, "myvar", zs, ("z",))
+            else
+                defDim(nc, "time", length(times))
+                defVar(nc, "time", times, ("time",))
+                var = defVar(nc, "myvar", Float64, ("z", "time"))
+                for t in eachindex(times)
+                    var[:, t] = zs .* t
+                end
+            end
+        end
+        return path
+    end
+
+    # No sources at all
+    @test_throws contains("At least one DataSource") FileReaders.MultiColumnNCFileReader([],)
+
+    # Columns reading different variables
+    mixed = make_col("mc_mixedvar.nc", [DateTime(2000, 1, 1)])
+    @test_throws contains("same variable") FileReaders.MultiColumnNCFileReader([
+        FileReaders.DataSource(mixed, "myvar"),
+        FileReaders.DataSource(mixed, "z"),
+    ])
+
+    # Time-varying columns that share no common date
+    col_2001 = make_col("mc_2001.nc", [DateTime(2001, 1, 1)])
+    col_2002 = make_col("mc_2002.nc", [DateTime(2002, 1, 1)])
+    @test_throws contains("share no common dates") FileReaders.MultiColumnNCFileReader([
+        FileReaders.DataSource(col_2001, "myvar"),
+        FileReaders.DataSource(col_2002, "myvar"),
+    ])
+
+    # A mix of static and time-varying columns
+    static_col = make_col("mc_static.nc", nothing)
+    tv_col = make_col("mc_tv.nc", [DateTime(2000, 1, 1)])
+    @test_throws contains("Some columns have a time dimension and some do not") FileReaders.MultiColumnNCFileReader([
+        FileReaders.DataSource(static_col, "myvar"),
+        FileReaders.DataSource(tv_col, "myvar"),
+    ])
+
+    # Reading a date that is not in the dataset
+    valid = make_col("mc_valid.nc", [DateTime(2000, 1, 1)])
+    ncreader = FileReaders.MultiColumnNCFileReader(
+        FileReaders.DataSource(valid, "myvar"),
+    )
+    @test_throws contains("is not available in column") FileReaders.read(
+        ncreader,
+        DateTime(1999, 1, 1),
+    )
+    close(ncreader)
+
+    # A column with no identifiable longitude/latitude
+    nocoords_path = joinpath(data_dir, "mc_nocoords.nc")
+    NCDataset(nocoords_path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defVar(nc, "z", zs, ("z",))
+        defVar(nc, "myvar", zs, ("z",))
+    end
+    @test_throws contains("No longitude/latitude variables identified") FileReaders.MultiColumnNCFileReader(
+        FileReaders.DataSource(nocoords_path, "myvar"),
+    )
+
+    FileReaders.close_all_ncfiles()
+    @test isempty(open_ncfiles)
+end

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -6,6 +6,193 @@ import ClimaUtilities
 import ClimaUtilities.FileReaders
 using NCDatasets
 
+@testset "DataSource" begin
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+    times = [DateTime(2000, 1, 1), DateTime(2000, 1, 2)]
+
+    # Write a single column file. `times === nothing` makes a static file (no
+    # time dimension); otherwise the file is time-varying with the given axis.
+    function make_source_file(name, times)
+        path = joinpath(data_dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, "z", length(zs))
+            defVar(nc, "z", zs, ("z",))
+            if isnothing(times)
+                defVar(nc, "myvar", zs, ("z",))
+            else
+                defDim(nc, "time", length(times))
+                defVar(nc, "time", times, ("time",))
+                var = defVar(nc, "myvar", Float64, ("z", "time"))
+                for t in eachindex(times)
+                    var[:, t] = zs .* t
+                end
+            end
+        end
+        return path
+    end
+
+    # Static single file: no time dimension
+    static_path = make_source_file("ds_static.nc", nothing)
+    src = FileReaders.DataSource(static_path, "myvar")
+    @test src.file_paths == [static_path]
+    @test src.varname == "myvar"
+    @test isempty(src.available_dates)
+    @test src.time_index == -1
+    @test src.coord_names == (; z = "z")
+    @test src.dataset_kwargs == ()
+
+    # Time-varying single file
+    tv_path = make_source_file("ds_tv.nc", times)
+    src = FileReaders.DataSource(tv_path, "myvar")
+    @test src.available_dates == times
+    @test src.time_index == 2
+    @test src.dataset_kwargs == ()
+
+    # `time_transform` is applied elementwise to the dates
+    src = FileReaders.DataSource(
+        tv_path,
+        "myvar";
+        time_transform = d -> d + Day(1),
+    )
+    @test src.available_dates == times .+ Day(1)
+
+    # Multiple files joined along the time dimension
+    split_paths = map(eachindex(times)) do t
+        make_source_file("ds_split_t$t.nc", [times[t]])
+    end
+    src = FileReaders.DataSource(split_paths, "myvar")
+    @test src.available_dates == times
+    @test src.time_index == 2
+    @test src.dataset_kwargs == (:aggdim => "time", :deferopen => false)
+
+    # Coordinates must be consistent across files
+    mismatch_path = joinpath(data_dir, "ds_split_zmismatch.nc")
+    NCDataset(mismatch_path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defVar(nc, "z", zs .+ 0.5, ("z",))
+        defDim(nc, "time", 1)
+        defVar(nc, "time", [times[2]], ("time",))
+        var = defVar(nc, "myvar", Float64, ("z", "time"))
+        var[:, 1] = zs
+    end
+    @test_throws contains("does not match") FileReaders.DataSource(
+        [first(split_paths), mismatch_path],
+        "myvar",
+    )
+
+    # File with date dimension
+    # Some datasets store their time axis as a "date" dimension holding integer
+    # yyyymmdd values instead of a CF "time" dimension
+    data_dir = mktempdir()
+    dates_int = [20000101, 20000102]
+    dates = [DateTime(2000, 1, 1), DateTime(2000, 1, 2)]
+    path = joinpath(data_dir, "ds_yyyymmdd.nc")
+    NCDataset(path, "c") do nc
+        defDim(nc, "date", length(dates_int))
+        defVar(nc, "date", dates_int, ("date",))
+        var = defVar(nc, "myvar", Float64, ("date",))
+        for t in eachindex(dates_int)
+            var[t] = t
+        end
+    end
+
+    src = FileReaders.DataSource(path, "myvar")
+    @test src.available_dates == dates
+    @test src.time_index == 1
+    @test isempty(src.dataset_kwargs)
+
+    # Error handling
+    @test_throws contains("must contain at least one path") FileReaders.DataSource(
+        String[],
+        "myvar",
+    )
+    @test_throws contains("is not available") FileReaders.DataSource(
+        static_path,
+        "nope",
+    )
+    unsorted_path = make_source_file("ds_unsorted.nc", reverse(times))
+    @test_throws contains("Dates are not sorted") FileReaders.DataSource(
+        unsorted_path,
+        "myvar",
+    )
+    duplicate_path = make_source_file("ds_duplicate.nc", [times[1], times[1]])
+    @test_throws contains("Dates are not unique") FileReaders.DataSource(
+        duplicate_path,
+        "myvar",
+    )
+end
+
+@testset "DataSource coordinate names" begin
+    data_dir = mktempdir()
+    zs = Float64[1, 2, 3]
+
+    # Write a single static column file whose coordinate variables use the
+    # given names.
+    function make_coord_file(name, lon_name, lat_name, z_name)
+        path = joinpath(data_dir, name)
+        NCDataset(path, "c") do nc
+            defDim(nc, z_name, length(zs))
+            defVar(nc, lon_name, 10.0, ())
+            defVar(nc, lat_name, 20.0, ())
+            defVar(nc, z_name, zs, (z_name,))
+            defVar(nc, "myvar", zs, (z_name,))
+        end
+        return path
+    end
+
+    # Coordinate names should match case-insensitively
+    detected_path =
+        make_coord_file("cn_detected.nc", "Longitude", "lat", "level")
+    src = FileReaders.DataSource(detected_path, "myvar")
+    @test src.coord_names == (; lon = "Longitude", lat = "lat", z = "level")
+
+    # Explicit names are validated against the file and stored as given
+    custom_path = make_coord_file("cn_custom.nc", "x_lon", "y_lat", "zed")
+    src = FileReaders.DataSource(
+        custom_path,
+        "myvar";
+        coord_names = (; lon = "x_lon", lat = "y_lat", z = "zed"),
+    )
+    @test src.coord_names == (; lon = "x_lon", lat = "y_lat", z = "zed")
+
+    # Detection omits the coordinate types it cannot identify
+    src = FileReaders.DataSource(custom_path, "myvar")
+    @test src.coord_names == (;)
+
+    # Two candidates for the same type of coordinate
+    ambiguous_path = joinpath(data_dir, "cn_ambiguous.nc")
+    NCDataset(ambiguous_path, "c") do nc
+        defDim(nc, "z", length(zs))
+        defVar(nc, "lon", 10.0, ())
+        defVar(nc, "longitude", 10.0, ())
+        defVar(nc, "latitude", 20.0, ())
+        defVar(nc, "z", zs, ("z",))
+        defVar(nc, "myvar", zs, ("z",))
+    end
+    @test_throws contains("multiple lon variables") FileReaders.DataSource(
+        ambiguous_path,
+        "myvar",
+    )
+
+    # Error handling for explicit names
+    @test_throws contains("is not available") FileReaders.DataSource(
+        custom_path,
+        "myvar";
+        coord_names = (; lon = "nope", lat = "y_lat"),
+    )
+    @test_throws contains("Unrecognized coordinate types") FileReaders.DataSource(
+        custom_path,
+        "myvar";
+        coord_names = (; long = "x_lon", lat = "y_lat"),
+    )
+    @test_throws contains("must be a NamedTuple") FileReaders.DataSource(
+        custom_path,
+        "myvar";
+        coord_names = ("x_lon", "y_lat"),
+    )
+end
+
 @testset "NCFileReader with time" begin
     # Start from a clean OPEN_NCFILES state
     FileReaders.close_all_ncfiles()

--- a/test/regridders.jl
+++ b/test/regridders.jl
@@ -637,3 +637,211 @@ end
         @test original_min <= regridded_min
     end
 end
+
+@testset "ColumnRegridder" begin
+    latlong_points = [(0.0, 0.0), (10.0, 20.0), (-5.0, 90.0)]
+    ncolumns = length(latlong_points)
+
+    for FT in (Float32, Float64)
+        points = [
+            ClimaCore.Geometry.LatLongPoint(FT(lat), FT(long)) for
+            (lat, long) in latlong_points
+        ]
+        target_space = make_column_space(
+            FT;
+            context,
+            points,
+            z_elem = 10,
+            z_min = FT(0),
+            z_max = FT(10_000),
+        )
+        target_z = ClimaCore.Fields.field2array(
+            ClimaCore.Fields.coordinate_field(target_space).z,
+        )
+
+        # Source grid spanning the full target range, same for every column.
+        source_z = stack([FT[0, 5000, 10_000] for _ in 1:ncolumns])
+        reg = Regridders.ColumnRegridder(target_space, source_z)
+
+        # Interpolate with f(z) = z
+        field = Regridders.regrid(reg, source_z)
+        @test eltype(field) == FT
+        @test Array(ClimaCore.Fields.field2array(field)) ≈ Array(target_z)
+
+        # Interpolate with f_c(z) = c * z (different values for each column)
+        data = stack([FT(c) .* source_z[:, c] for c in 1:ncolumns])
+        field = Regridders.regrid(reg, data)
+        expected = stack([FT(c) .* target_z[:, c] for c in 1:ncolumns])
+        @test Array(ClimaCore.Fields.field2array(field)) ≈ Array(expected)
+
+        # Test flat extrapolation
+        source_z_narrow = stack([FT[2000, 5000, 8000] for _ in 1:ncolumns])
+        reg_narrow = Regridders.ColumnRegridder(target_space, source_z_narrow)
+        field = Regridders.regrid(reg_narrow, source_z_narrow)
+        @test Array(ClimaCore.Fields.field2array(field)) ≈
+              clamp.(Array(target_z), FT(2000), FT(8000))
+
+        # Decreasing source levels are detected automatically
+        source_z_dec = reverse(source_z, dims = 1)
+        reg_reversed = Regridders.ColumnRegridder(target_space, source_z_dec)
+        field_reversed = Regridders.regrid(reg_reversed, source_z_dec)
+        @test Array(ClimaCore.Fields.field2array(field_reversed)) ≈
+              Array(target_z)
+
+        # Surface data with no vertical levels
+        level_space = ClimaCore.Spaces.level(target_space, 1)
+        reg_surface = Regridders.ColumnRegridder(level_space)
+        surface_data = reshape(FT[1, 2, 3], 1, ncolumns)
+        field_surface = Regridders.regrid(reg_surface, surface_data)
+        @test vec(Array(ClimaCore.Fields.field2array(field_surface))) ==
+              FT[1, 2, 3]
+
+        # Test combination of increasing and decreasing vertical levels for
+        # spaces
+        for target_reverse in (false, true)
+            target_space = make_column_space(
+                FT;
+                context,
+                points,
+                z_elem = 10,
+                z_min = FT(0),
+                z_max = FT(10_000),
+                reverse_mode = target_reverse,
+            )
+            target_z = ClimaCore.Fields.field2array(
+                ClimaCore.Fields.coordinate_field(target_space).z,
+            )
+            # Confirm we actually built the intended target ordering
+            @test issorted(Array(target_z)[:, 1], rev = target_reverse)
+
+            # Source grid (increasing), spanning the full target range
+            source_z_inc =
+                stack([FT[0, 2500, 5000, 7500, 10_000] for _ in 1:ncolumns])
+
+            for source_reverse in (false, true)
+                source_z =
+                    source_reverse ? reverse(source_z_inc, dims = 1) :
+                    source_z_inc
+                reg = Regridders.ColumnRegridder(target_space, source_z)
+
+                # Interpolate with f(z) = z
+                field = Regridders.regrid(reg, source_z)
+                @test eltype(field) == FT
+                @test Array(ClimaCore.Fields.field2array(field)) ≈
+                      Array(target_z)
+
+                # Interpolate with f_c(z) = c * z (different values for each column)
+                data = stack([FT(c) .* source_z[:, c] for c in 1:ncolumns])
+                field = Regridders.regrid(reg, data)
+                expected = stack([FT(c) .* target_z[:, c] for c in 1:ncolumns])
+                @test Array(ClimaCore.Fields.field2array(field)) ≈
+                      Array(expected)
+            end
+        end
+
+        # Test with different spaces
+        # Interpolate with single-column FiniteDifferenceSpace
+        column_space = ClimaCore.CommonSpaces.ColumnSpace(
+            FT;
+            context,
+            z_elem = 10,
+            z_min = FT(0),
+            z_max = FT(10_000),
+            staggering = ClimaCore.CommonSpaces.CellCenter(),
+        )
+        target_z = ClimaCore.Fields.field2array(
+            ClimaCore.Fields.coordinate_field(column_space).z,
+        )
+        @test size(target_z, 2) == 1  # a single column
+
+        source_z = stack([FT[0, 2500, 5000, 7500, 10_000]])
+        reg = Regridders.ColumnRegridder(column_space, source_z)
+
+        # f(z) = z
+        field = Regridders.regrid(reg, source_z)
+        @test eltype(field) == FT
+        @test Array(ClimaCore.Fields.field2array(field)) ≈ Array(target_z)
+
+        # f(z) = 3 * z
+        data = FT(3) .* source_z
+        field = Regridders.regrid(reg, data)
+        @test Array(ClimaCore.Fields.field2array(field)) ≈
+              FT(3) .* Array(target_z)
+
+        # Flat extrapolation outside the (narrower) source range
+        source_z_narrow = stack([FT[2000, 5000, 8000]])
+        reg_narrow = Regridders.ColumnRegridder(column_space, source_z_narrow)
+        field = Regridders.regrid(reg_narrow, source_z_narrow)
+        @test Array(ClimaCore.Fields.field2array(field)) ≈
+              clamp.(Array(target_z), FT(2000), FT(8000))
+
+        # Interpolate onto PointSpace
+        point_space = ClimaCore.Spaces.level(column_space, 1)
+        reg_surface = Regridders.ColumnRegridder(point_space)
+        surface_data = reshape(FT[42], 1, 1)
+        field_surface = Regridders.regrid(reg_surface, surface_data)
+        @test vec(Array(ClimaCore.Fields.field2array(field_surface))) == FT[42]
+    end
+
+    # Error handling
+    FT = Float64
+    column_space = ClimaCore.CommonSpaces.ColumnSpace(
+        FT;
+        context,
+        z_elem = 10,
+        z_min = FT(0),
+        z_max = FT(10_000),
+        staggering = ClimaCore.CommonSpaces.CellCenter(),
+    )
+
+    # Non-monotone source levels
+    @test_throws contains("neither strictly increasing nor strictly decreasing") Regridders.ColumnRegridder(
+        column_space,
+        stack([FT[0, 5000, 2500, 10_000]]),
+    )
+
+    # Repeated source levels
+    @test_throws contains("neither strictly increasing nor strictly decreasing") Regridders.ColumnRegridder(
+        column_space,
+        stack([FT[0, 2500, 2500, 10_000]]),
+    )
+
+    # Wrong number of columns
+    @test_throws contains("columns") Regridders.ColumnRegridder(
+        column_space,
+        stack([FT[0, 5000, 10_000] for _ in 1:2]),
+    )
+
+    # Source levels given for a target space without vertical levels
+    point_space = ClimaCore.Spaces.level(column_space, 1)
+    @test_throws contains("Cannot regrid onto the target space") Regridders.ColumnRegridder(
+        point_space,
+        stack([FT[0, 5000, 10_000]]),
+    )
+
+    # Data size must match the source levels
+    source_z = stack([FT[0, 5000, 10_000]])
+    reg = Regridders.ColumnRegridder(column_space, source_z)
+    @test_throws contains("does not match") Regridders.regrid(
+        reg,
+        stack([FT[0, 10_000]]),
+    )
+
+    # Columns with inconsistent directions
+    two_col_space = make_column_space(
+        FT;
+        context,
+        points = [
+            ClimaCore.Geometry.LatLongPoint(FT(0), FT(0)),
+            ClimaCore.Geometry.LatLongPoint(FT(10), FT(20)),
+        ],
+        z_elem = 10,
+        z_min = FT(0),
+        z_max = FT(10_000),
+    )
+    mixed_z = stack([FT[0, 5000, 10_000], FT[10_000, 5000, 0]])
+    @test_throws contains("inconsistent directions") Regridders.ColumnRegridder(
+        two_col_space,
+        mixed_z,
+    )
+end

--- a/test/space_varying_inputs.jl
+++ b/test/space_varying_inputs.jl
@@ -1,12 +1,15 @@
 using Test
 
 import ClimaUtilities
+import ClimaUtilities.DataHandling
+import ClimaUtilities.FileReaders
 using ClimaUtilities.SpaceVaryingInputs: SpaceVaryingInput
 
 import ClimaComms
 @static pkgversion(ClimaComms) >= v"0.6" && ClimaComms.@import_required_backends
 using ClimaCore
 using Interpolations
+using NCDatasets
 
 const context = ClimaComms.context()
 ClimaComms.init(context)
@@ -52,4 +55,40 @@ AT = ClimaComms.array_type(ClimaComms.device())
     @test parent(field_of_structs.c)[:] ≈
           AT(collect(range(FT(0.15), FT(2.85), 10)))
 
+end
+
+@testset "SpaceVaryingInput with MultiColumnDataHandler" begin
+    FT = Float32
+    long, lat = FT(20), FT(10)
+    profile = FT[10, 20, 30, 40]
+    nz = length(profile)
+    target_space = make_column_space(
+        FT;
+        context,
+        points = [ClimaCore.Geometry.LatLongPoint(lat, long)],
+        z_elem = nz,
+        z_min = FT(0.5),
+        z_max = FT(nz + 0.5),
+    )
+
+    PATH = joinpath(mktempdir(), "svi_col.nc")
+    NCDataset(PATH, "c") do nc
+        defDim(nc, "z", nz)
+        defVar(nc, "longitude", long, ())
+        defVar(nc, "latitude", lat, ())
+        defVar(nc, "z", FT[1, 2, 3, 4], ("z",))
+        defVar(nc, "sp", profile, ("z",))
+    end
+
+    data_handler = DataHandling.MultiColumnDataHandler(
+        [FileReaders.DataSource(PATH, "sp")],
+        target_space,
+    )
+    field = SpaceVaryingInput(data_handler)
+    @test field isa ClimaCore.Fields.Field
+    @test axes(field) == target_space
+    # Source and target z are the same, so no interpolation should be done
+    @test vec(Array(ClimaCore.Fields.field2array(field))) ≈ profile
+
+    close(data_handler)
 end

--- a/test/time_varying_inputs.jl
+++ b/test/time_varying_inputs.jl
@@ -4,6 +4,7 @@ using Artifacts
 
 import ClimaUtilities
 import ClimaUtilities: DataHandling
+import ClimaUtilities: FileReaders
 import ClimaUtilities: TimeVaryingInputs
 using ClimaUtilities.TimeManager
 
@@ -410,5 +411,215 @@ end
                 start_date,
             )
         end
+    end
+end
+
+@testset "TimeVaryingInput with MultiColumnDataHandler" begin
+    for FT in (Float32, Float64)
+        lon1, lat1 = FT(20), FT(10)
+        lon2, lat2 = FT(40), FT(50)
+        nz = 4
+        dates = [DateTime(2000, 1, 1) + Day(t) for t in 0:2]
+        start_date = dates[1]
+
+        target_space = make_column_space(
+            FT;
+            context,
+            points = [
+                Geometry.LatLongPoint(lat1, lon1),
+                Geometry.LatLongPoint(lat2, lon2),
+            ],
+            z_elem = nz,
+            z_min = FT(0.5),
+            z_max = FT(nz + 0.5),
+        )
+
+        # The source z levels coincide with the cell centers of the target
+        # space, so the vertical interpolation reproduces the profiles exactly.
+        # The profile of a column with scale c at the t-th date is
+        # c * t * [1, 2, 3, 4].
+        dir = mktempdir()
+        function write_col(name, lon, lat, scale)
+            path = joinpath(dir, name)
+            NCDatasets.NCDataset(path, "c") do nc
+                NCDatasets.defDim(nc, "z", nz)
+                NCDatasets.defDim(nc, "time", length(dates))
+                NCDatasets.defVar(nc, "longitude", lon, ())
+                NCDatasets.defVar(nc, "latitude", lat, ())
+                NCDatasets.defVar(nc, "z", FT[1, 2, 3, 4], ("z",))
+                NCDatasets.defVar(nc, "time", dates, ("time",))
+                var = NCDatasets.defVar(nc, "sp", FT, ("z", "time"))
+                for t in eachindex(dates)
+                    var[:, t] = scale .* t .* FT[1, 2, 3, 4]
+                end
+            end
+            return path
+        end
+
+        scale1, scale2 = FT(1), FT(10)
+        sources = [
+            FileReaders.DataSource(
+                write_col("col1.nc", lon1, lat1, scale1),
+                "sp",
+            ),
+            FileReaders.DataSource(
+                write_col("col2.nc", lon2, lat2, scale2),
+                "sp",
+            ),
+        ]
+
+        data_handler = DataHandling.MultiColumnDataHandler(
+            sources,
+            target_space;
+            start_date,
+        )
+
+        # The handler matches the columns to the space by location, so order
+        # the scales by the space's longitudes
+        coords = Fields.coordinate_field(target_space)
+        lons = Array(Fields.field2array(coords.long))[1, :]
+        scales = [isapprox(lon, lon1) ? scale1 : scale2 for lon in lons]
+        expected(t) = stack([scale .* t .* FT[1, 2, 3, 4] for scale in scales])
+
+        dest = Fields.zeros(target_space)
+        one_day = 86400.0
+
+        input = TimeVaryingInputs.TimeVaryingInput(data_handler)
+
+        @test one_day in input
+        @test !(-one_day in input)
+
+        # On the second snapshot
+        TimeVaryingInputs.evaluate!(dest, input, one_day)
+        @test Array(Fields.field2array(dest)) ≈ expected(2)
+
+        # Halfway between the first two snapshots
+        # The data is linear in time, so linear interpolation is exact
+        TimeVaryingInputs.evaluate!(dest, input, one_day / 2)
+        @test Array(Fields.field2array(dest)) ≈ expected(1.5)
+
+        # Same, with the time as a DateTime and as an ITime
+        TimeVaryingInputs.evaluate!(dest, input, DateTime(2000, 1, 1, 12))
+        @test Array(Fields.field2array(dest)) ≈ expected(1.5)
+
+        TimeVaryingInputs.evaluate!(
+            dest,
+            input,
+            ITime(43200; epoch = start_date),
+        )
+        @test Array(Fields.field2array(dest)) ≈ expected(1.5)
+
+        # Out of range
+        @test_throws ErrorException TimeVaryingInputs.evaluate!(
+            dest,
+            input,
+            -one_day,
+        )
+
+        input_nearest = TimeVaryingInputs.TimeVaryingInput(
+            data_handler;
+            method = TimeVaryingInputs.NearestNeighbor(),
+        )
+        TimeVaryingInputs.evaluate!(dest, input_nearest, 0.7 * one_day)
+        @test Array(Fields.field2array(dest)) ≈ expected(2)
+
+        # Out of range with Flat, on both sides
+        input_flat = TimeVaryingInputs.TimeVaryingInput(
+            data_handler;
+            method = TimeVaryingInputs.LinearInterpolation(
+                TimeVaryingInputs.Flat(),
+            ),
+        )
+        TimeVaryingInputs.evaluate!(dest, input_flat, -one_day)
+        @test Array(Fields.field2array(dest)) ≈ expected(1)
+        TimeVaryingInputs.evaluate!(dest, input_flat, 10 * one_day)
+        @test Array(Fields.field2array(dest)) ≈ expected(3)
+
+        close(input)
+    end
+end
+
+@testset "TimeVaryingInput with MultiColumnDataHandler, vertical interp" begin
+    for FT in (Float32, Float64), source_reverse in (false, true)
+        lon1, lat1 = FT(20), FT(10)
+        lon2, lat2 = FT(40), FT(50)
+        dates = [DateTime(2000, 1, 1) + Day(t) for t in 0:2]
+        start_date = dates[1]
+
+        # Target cell centers are 1.0, 3.0, 5.0, 7.0 (z_elem = 4 over [0, 8])
+        target_space = make_column_space(
+            FT;
+            context,
+            points = [
+                Geometry.LatLongPoint(lat1, lon1),
+                Geometry.LatLongPoint(lat2, lon2),
+            ],
+            z_elem = 4,
+            z_min = FT(0),
+            z_max = FT(8),
+        )
+
+        # Each column has its own linear profile a + b * z
+        src_z1, src_z2 = FT[0, 4, 8], FT[0, 5, 8]
+        profile1(z) = FT(2) + FT(3) * z
+        profile2(z) = FT(5) + FT(1) * z
+
+        dir = mktempdir()
+        function write_col(name, lon, lat, src_z, profile)
+            zs = source_reverse ? reverse(src_z) : src_z
+            path = joinpath(dir, name)
+            NCDatasets.NCDataset(path, "c") do nc
+                NCDatasets.defDim(nc, "z", length(zs))
+                NCDatasets.defDim(nc, "time", length(dates))
+                NCDatasets.defVar(nc, "longitude", lon, ())
+                NCDatasets.defVar(nc, "latitude", lat, ())
+                NCDatasets.defVar(nc, "z", zs, ("z",))
+                NCDatasets.defVar(nc, "time", dates, ("time",))
+                var = NCDatasets.defVar(nc, "sp", FT, ("z", "time"))
+                for t in eachindex(dates)
+                    var[:, t] = t .* profile.(zs)
+                end
+            end
+            return path
+        end
+
+        sources = [
+            FileReaders.DataSource(
+                write_col("col1.nc", lon1, lat1, src_z1, profile1),
+                "sp",
+            ),
+            FileReaders.DataSource(
+                write_col("col2.nc", lon2, lat2, src_z2, profile2),
+                "sp",
+            ),
+        ]
+
+        data_handler = DataHandling.MultiColumnDataHandler(
+            sources,
+            target_space;
+            start_date,
+        )
+
+        # Columns follow the target points: column 1 is profile1 (2 + 3z),
+        # column 2 is profile2 (5 + z), sampled at the cell centers 1, 3, 5, 7.
+        # The values below scale those profiles by the time factor (2 on the
+        # second snapshot, 1.5 midway) and do not depend on `source_reverse`.
+        expected_snapshot = FT[10 12; 22 16; 34 20; 46 24]
+        expected_halfway = FT[7.5 9; 16.5 12; 25.5 15; 34.5 18]
+
+        dest = Fields.zeros(target_space)
+        one_day = 86400.0
+        input = TimeVaryingInputs.TimeVaryingInput(data_handler)
+
+        # On the second snapshot: only vertical interpolation happens
+        TimeVaryingInputs.evaluate!(dest, input, one_day)
+        @test Array(Fields.field2array(dest)) ≈ expected_snapshot
+
+        # Between snapshots: the data is linear in both z and time, so the
+        # combined interpolation is still exact
+        TimeVaryingInputs.evaluate!(dest, input, one_day / 2)
+        @test Array(Fields.field2array(dest)) ≈ expected_halfway
+
+        close(input)
     end
 end


### PR DESCRIPTION
This is building on top of https://github.com/CliMA/ClimaCore.jl/pull/2525 which add support for spaces with multiple columns. To complete https://github.com/CliMA/ClimaLand.jl/issues/1723, this PR adds support for loading data from datasets which each dataset represents a single column. In addition to this, regridding along the vertical direction for this kind of data is also added in this PR. Note that for ClimaLand, the forcing data for the single column runs is only on the surface which means that no interpolation is done and only a memcopy is done. An example of this working in ClimaLand can be found [here](https://github.com/CliMA/ClimaLand.jl/tree/kp/multi-cols) (note that most of the code there is generated by LLM and it is more of a proof of concept than something that is ready to be merge).

Note that most of the code generated in this PR is done by LLM and verified by me.

# Design Notes

Here's a list of brief design considerations and notes for each struct.

## `ColumnRegridder`

This is needed since `InterpolationsRegridder` can't handle regridding non-gridded source data. Note that you can still use `InterpolationRegridder` with the new spaces since all the ClimaCore spaces are non-gridded. 

## `DataSource` 
This struct exists to simplify the logic of the input arguments to MultiColumnNCFileReader. Otherwise, this would be a vector of vectors of vector of vectors of datasets representing columns. The each level of the vectors correspond to time concatenation of datasets, different variables, and different columns.

This is also needed to support time preprocessing which is not currently available. For ClimaLand, each column has its own UTC offset, so a single time preprocessing function can't be used here. It must be done for each column.

One thing that isn't done is storing the dimension values which I am not sure if it should be added or not.

In the future, this can be used to support other types of datasets (not just NetCDF files) but would require a bit more functionality such as opening and closing datasets. Also, `DataSource` can also be used in the `NCFileReader` but it is not done in this PR to avoid more changes.

## `MultiColumnNCFileReader`
 
The different requirements than the `NCFileReader` with the kind of checks that we need to do and the reading of files is slightly different. I don't think it is possible to adapt `NCFileReader` to make it work with the kind of data that we are handling.

## `MultiColumnDataHandler`

The fields of this struct are identical to the `DataHandler`. One way to avoid code duplication is to use a trait system (`e.g. `Column` vs `Gridded`). Multiple dispatch can't be used here since the current list of arguments doesn't give anything to dispatch off of.

This struct should be able to support spaces that have a single column, but it does not right now to simplify the code that need to be written.

## Other considerations

I haven't benchmark this code against the existing code, but I suspected that reading from N datasets can be slow. It might be worth looking into a ring buffer instead of a LRU cache and make the cache size big enough to store all the data of the datasets before the simulation began.

# Questions

1. Columns are chosen at the level of the `MultiColumnDataHandler`. I am not sure if this is the best place to do this kind of thing or if the feature should be added. It introduces a lot of complexity to the code, since we need to open the datasets and look for this kind of information (although this can be done when making the `DataSource` objects). In addition, it imposes a requirement that datasets have that information which I am not sure that all datasets have. However, it does make it convenient for the users and remove possible user errors if the users didn't list the columns in the right order. 
2. Are there datasets that don't have a longitude and latitude directions supported? Is this something we need to support if this will be used in ClimaAtmos single column runs? Maybe there need to be a feature to disable this check?

# TODO

- [ ] User facing documentation for all structs
- [x] Check GPU compatibility