### PR TITLE
Use binary search instead of linear scans

### DIFF
--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -530,7 +530,7 @@ function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
 end
 
 """
-    DataHandling.previous_date(data_handler::DataHandler, time::Dates.TimeType)
+    DataHandling.previous_date(data_handler::DataHandler, date::Dates.TimeType)
 
 Return the date of the snapshot before the given `date`.
 If `date` is one of the snapshots, return itself.
@@ -551,10 +551,10 @@ function DataHandling.previous_date(
 end
 
 """
-    DataHandling.next_date(data_handler::DataHandler, time::Dates.TimeType)
+    DataHandling.next_date(data_handler::DataHandler, date::Dates.TimeType)
 
-Return the date of the snapshot after the given `time`.
-If `date` is one of the snapshots, return itself.
+Return the date of the snapshot after the given `date`.
+If `date` is one of the snapshots, return the next date.
 
 If `date` is not in the `data_handler`, return an error.
 """

--- a/ext/DataHandlingExt.jl
+++ b/ext/DataHandlingExt.jl
@@ -493,12 +493,9 @@ function DataHandling.previous_time(
     data_handler::DataHandler,
     date::Dates.DateTime,
 )
-    # We have to handle separately what happens when we are on the node
-    if date in data_handler.available_dates
-        index = searchsortedfirst(data_handler.available_dates, date)
-    else
-        index = searchsortedfirst(data_handler.available_dates, date) - 1
-    end
+    # searchsortedlast returns the index of the last date <= the given date, which is the
+    # snapshot itself when on a node and the previous one otherwise
+    index = searchsortedlast(data_handler.available_dates, date)
     index < 1 && error("Date $date is before available dates")
     return data_handler.available_times[index]
 end
@@ -518,12 +515,9 @@ function DataHandling.next_time(data_handler::DataHandler, time::AbstractFloat)
 end
 
 function DataHandling.next_time(data_handler::DataHandler, date::Dates.DateTime)
-    # We have to handle separately what happens when we are on the node
-    if date in data_handler.available_dates
-        index = searchsortedfirst(data_handler.available_dates, date) + 1
-    else
-        index = searchsortedfirst(data_handler.available_dates, date)
-    end
+    # searchsortedlast returns the index of the last date <= the given date, which is one
+    # before the next snapshot, so we add one (also correct when on a node)
+    index = searchsortedlast(data_handler.available_dates, date) + 1
     index > length(data_handler.available_dates) &&
         error("Date $date is after available dates")
     return data_handler.available_times[index]
@@ -541,11 +535,9 @@ function DataHandling.previous_date(
     data_handler::DataHandler,
     date::Dates.TimeType,
 )
-    if date in data_handler.available_dates
-        index = searchsortedfirst(data_handler.available_dates, date)
-    else
-        index = searchsortedfirst(data_handler.available_dates, date) - 1
-    end
+    # searchsortedlast returns the index of the last date <= the given date, which is the
+    # snapshot itself when on a node and the previous one otherwise
+    index = searchsortedlast(data_handler.available_dates, date)
     index < 1 && error("Date $date is before available dates")
     return data_handler.available_dates[index]
 end
@@ -559,11 +551,9 @@ If `date` is one of the snapshots, return the next date.
 If `date` is not in the `data_handler`, return an error.
 """
 function DataHandling.next_date(data_handler::DataHandler, date::Dates.TimeType)
-    if date in data_handler.available_dates
-        index = searchsortedfirst(data_handler.available_dates, date) + 1
-    else
-        index = searchsortedfirst(data_handler.available_dates, date)
-    end
+    # searchsortedlast returns the index of the last date <= the given date, which is one
+    # before the next snapshot, so we add one (also correct when on a node)
+    index = searchsortedlast(data_handler.available_dates, date) + 1
     index > length(data_handler.available_dates) &&
         error("Date $date is after available dates")
     return data_handler.available_dates[index]
@@ -594,7 +584,7 @@ function DataHandling.regridded_snapshot(
     # Dates.DateTime(0) is the cache key for static maps
     if date != Dates.DateTime(0)
         file_paths = data_handler.file_readers[first(varnames)].file_paths
-        date in data_handler.available_dates ||
+        insorted(date, data_handler.available_dates) ||
             error("Date $date not available in files $(file_paths)")
     end
 

--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -345,11 +345,11 @@ function FileReaders.read!(
     end
 
     dest .= get!(file_reader._cached_reads, date) do
-        index = findall(d -> d == date, file_reader.available_dates)
-        length(index) == 1 || error(
+        indices = searchsorted(file_reader.available_dates, date)
+        length(indices) == 1 || error(
             "Problem with date $date in one of $(file_reader.file_paths)",
         )
-        index = index[]
+        index = only(indices)
         var = file_reader.dataset[file_reader.varname]
         slicer = [
             i == file_reader.time_index ? index : Colon() for

--- a/ext/TimeVaryingInputsExt.jl
+++ b/ext/TimeVaryingInputsExt.jl
@@ -414,7 +414,7 @@ function TimeVaryingInputs.evaluate!(
 
     # We have to consider the edge case where time is precisely the last available_time.
     # This is relevant also because it can be triggered by LinearPeriodFilling
-    if time in DataHandling.available_dates(itp.data_handler)
+    if insorted(time, DataHandling.available_dates(itp.data_handler))
         regridded_snapshot!(dest, itp.data_handler, time)
     else
         date0, date1 = previous_date(itp.data_handler, time),

--- a/src/Utils.jl
+++ b/src/Utils.jl
@@ -37,7 +37,7 @@ returns the endpoint value closest.
 function linear_interpolation(indep_vars, dep_vars, indep_value)
     N = length(indep_vars)
     id = searchsortedfirst(indep_vars, indep_value)
-    indep_value in indep_vars && return dep_vars[id]
+    (id <= N && indep_vars[id] == indep_value) && return dep_vars[id]
     if id == 1
         dep_vars[begin]
     elseif id == N + 1


### PR DESCRIPTION
There are parts of the code that does a linear scan on `available_dates`. This is verified to be sorted at construction. As such, I updated the code to do a binary search instead of a linear scan whenever possible.

I asked a LLM to implement these changes.