### PR TITLE
Fix double close bug with NetCDF dataset registry

### DIFF
--- a/ext/NCFileReaderExt.jl
+++ b/ext/NCFileReaderExt.jl
@@ -70,6 +70,9 @@ struct NCFileReader{
 
     """Size of the output array. This is used by read to initialize an array."""
     output_size::Tuple{Vararg{Int}}
+
+    """Whether this reader has not been closed yet. Used to make `close` idempotent."""
+    is_open::Base.RefValue{Bool}
 end
 
 """
@@ -213,6 +216,7 @@ function FileReaders.NCFileReader(
             _cached_reads,
             time_index,
             output_size,
+            Ref(true),
         )
     catch
         _release_file(file_paths, varname)
@@ -260,6 +264,13 @@ end
 Close `NCFileReader`. If no other `NCFileReader` is using the same file, close the NetCDF file.
 """
 function Base.close(file_reader::NCFileReader)
+    file_reader.is_open[] || return nothing
+    file_reader.is_open[] = false
+    # After close_all_ncfiles, the same paths may map to a new dataset opened by
+    # other readers; only release the file if the registered dataset is ours
+    haskey(OPEN_NCFILES, file_reader.file_paths) || return nothing
+    dataset, _ = OPEN_NCFILES[file_reader.file_paths]
+    dataset === file_reader.dataset || return nothing
     _release_file(file_reader.file_paths, file_reader.varname)
     return nothing
 end

--- a/test/file_readers.jl
+++ b/test/file_readers.jl
@@ -93,15 +93,33 @@ end
         @test FileReaders.read(reader2, DateTime(2021, 01, 01, 01)) ==
               nc["sp"][:, :, 2]
 
-        # Check double close is an no-op
+        # Check double close is a no-op
         close(reader1)
-
+        @test haskey(open_ncfiles, reader2.file_paths)
+        @test FileReaders.read(reader2, DateTime(2021, 01, 01, 01)) ==
+              nc["sp"][:, :, 2]
         file_paths = reader2.file_paths
         close(reader2)
         @test !haskey(open_ncfiles, file_paths)
 
         # Check again that double close is an no-op
         close(reader2)
+        @test !haskey(open_ncfiles, file_paths)
+
+        # Check read from reader3 works after closing reader1 again
+        reader3 = FileReaders.NCFileReader(PATH, "sp")
+        close(reader1)
+        @test haskey(open_ncfiles, file_paths)
+        @test FileReaders.read(reader3, DateTime(2021, 01, 01, 01)) ==
+              nc["sp"][:, :, 2]
+
+        # Check same behavior if we close all NetCDF files instead of a specific
+        # reader
+        FileReaders.close_all_ncfiles()
+        reader4 = FileReaders.NCFileReader(PATH, "sp")
+        close(reader3)
+        @test haskey(open_ncfiles, file_paths)
+        close(reader4)
         @test !haskey(open_ncfiles, file_paths)
     end
 end


### PR DESCRIPTION
This PR fixes a double close bug with the NetCDF dataset registry. The bug is that you can call `close` multiple times on a single readers and it would close the NetCDF file when the count hits zero. This can leads to a reader not being able to read a file if there are two readers reading the same file and `close` was called multiple time on one of the reader.

To fix this, we make `close` idempotent by keeping track of the open readers.