### PR TITLE
Update ClimaCore extension

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,7 +16,6 @@ steps:
 
       - echo "--- Instantiate project"
       - "julia --project=test -e 'using Pkg; Pkg.develop(; path = \".\"); Pkg.add(\"MPI\"); Pkg.add(\"CUDA\")'"
-      - "julia --project=test -e 'using Pkg; Pkg.add(url=\"https://github.com/CliMA/ClimaCore.jl\", rev=\"main\")'
       - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=test -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=test -e 'using Pkg; Pkg.status()'"

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -16,6 +16,7 @@ steps:
 
       - echo "--- Instantiate project"
       - "julia --project=test -e 'using Pkg; Pkg.develop(; path = \".\"); Pkg.add(\"MPI\"); Pkg.add(\"CUDA\")'"
+      - "julia --project=test -e 'using Pkg; Pkg.add(url=\"https://github.com/CliMA/ClimaCore.jl\", rev=\"main\")'
       - "julia --project=test -e 'using Pkg; Pkg.instantiate(;verbose=true)'"
       - "julia --project=test -e 'using Pkg; Pkg.precompile()'"
       - "julia --project=test -e 'using Pkg; Pkg.status()'"

--- a/NEWS.md
+++ b/NEWS.md
@@ -3,6 +3,8 @@ ClimaUtilities.jl Release Notes
 
 main
 ------
+v0.1.31
+------
 ### Bug fixes
 
 - Fix bug where 0D and 2D/3D `TimeVaryingInput`s using the `Flat()`

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "ClimaUtilities"
 uuid = "b3f4f4ca-9299-4f7f-bd9b-81e1242a7513"
-version = "0.1.30"
+version = "0.1.31"
 authors = ["Gabriele Bozzola <gbozzola@caltech.edu>", "Julia Sloan <jsloan@caltech.edu>", "Kevin Phan <kphan2@caltech.edu>"]
 
 [deps]
@@ -28,7 +28,7 @@ Adapt = "4"
 Artifacts = "1"
 CUDA = "5.5, 6"
 ClimaComms = "0.6.2"
-ClimaCore = "0.14.23"
+ClimaCore = "0.14.23, 0.15"
 ClimaCoreTempestRemap = "0.3.15"
 Dates = "1"
 Interpolations = "0.15.1, 0.16"

--- a/ext/TempestRegridderExt.jl
+++ b/ext/TempestRegridderExt.jl
@@ -119,40 +119,86 @@ function Regridders.regrid(regridder::TempestRegridder, date::Dates.DateTime)
     )
 end
 
-"""
-    reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
+@static if pkgversion(ClimaCore) >= v"0.15.0"
+    """
+        reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
 
-Reshapes a sparse vector array `in_array` (CGLL, raw output of the TempestRemap),
-and uses its data to populate the input Field object `field`.
-Redundant nodes are populated using `dss` operations.
+    Reshapes a sparse vector array `in_array` (CGLL, raw output of the TempestRemap),
+    and uses its data to populate the input Field object `field`.
+    Redundant nodes are populated using `dss` operations.
 
-Code taken from ClimaCoupler.Regridder.
+    Code taken from ClimaCoupler.Regridder.
 
-# Arguments
-- `field`: [Fields.Field] object populated with the input array.
-- `in_array`: [Array] input used to fill `field`.
-- `R`: [NamedTuple] containing `target_idxs` and `row_indices` used for indexing.
-"""
-function reshape_cgll_sparse_to_field!(
-    field::ClimaCore.Fields.Field,
-    in_array::Array,
-    R,
-)
-    target = ClimaCore.Fields.field_values(field)
+    # Arguments
+    - `field`: [Fields.Field] object populated with the input array.
+    - `in_array`: [Array] input used to fill `field`.
+    - `R`: [NamedTuple] containing `target_idxs` and `row_indices` used for indexing.
+    """
+    function reshape_cgll_sparse_to_field!(
+        field::ClimaCore.Fields.Field,
+        in_array::Array,
+        R,
+    )
+        target = ClimaCore.Fields.field_values(field)
 
-    fill!(target, zero(eltype(target)))
-    for (n, row) in enumerate(R.row_indices)
-        it, jt, et = (
-            view(R.target_idxs[1], n),
-            view(R.target_idxs[2], n),
-            view(R.target_idxs[3], n),
-        )
-        target[1, it, jt, et] = in_array[row]
+        fill!(target, zero(eltype(target)))
+        for (n, row) in enumerate(R.row_indices)
+            it, jt, et = (
+                view(R.target_idxs[1], n),
+                view(R.target_idxs[2], n),
+                view(R.target_idxs[3], n),
+            )
+            @. target[1, it, jt, et] = in_array[row]
+        end
+
+        # broadcast to the redundant nodes using unweighted dss
+        topology = ClimaCore.Spaces.topology(axes(field))
+        ClimaCore.Topologies.dss!(target, topology)
     end
+else
+    """
+        reshape_cgll_sparse_to_field!(field::Fields.Field, in_array::Array, R)
 
-    # broadcast to the redundant nodes using unweighted dss
-    topology = ClimaCore.Spaces.topology(axes(field))
-    ClimaCore.Topologies.dss!(target, topology)
+    Reshapes a sparse vector array `in_array` (CGLL, raw output of the TempestRemap),
+    and uses its data to populate the input Field object `field`.
+    Redundant nodes are populated using `dss` operations.
+
+    Code taken from ClimaCoupler.Regridder.
+
+    # Arguments
+    - `field`: [Fields.Field] object populated with the input array.
+    - `in_array`: [Array] input used to fill `field`.
+    - `R`: [NamedTuple] containing `target_idxs` and `row_indices` used for indexing.
+    """
+    function reshape_cgll_sparse_to_field!(
+        field::ClimaCore.Fields.Field,
+        in_array::Array,
+        R,
+    )
+        field_array = parent(field)
+
+        fill!(field_array, zero(eltype(field_array)))
+        Nf = size(field_array, 3)
+
+        for (n, row) in enumerate(R.row_indices)
+            it, jt, et = (
+                view(R.target_idxs[1], n),
+                view(R.target_idxs[2], n),
+                view(R.target_idxs[3], n),
+            )
+            for f in 1:Nf
+                field_array[it, jt, f, et] .= in_array[row]
+            end
+        end
+
+        # broadcast to the redundant nodes using unweighted dss
+        space = axes(field)
+        topology = ClimaCore.Spaces.topology(space)
+        hspace = ClimaCore.Spaces.horizontal_space(space)
+        target = ClimaCore.Fields.field_values(field)
+
+        ClimaCore.Topologies.dss!(target, topology)
+    end
 end
 
 """

--- a/ext/TempestRegridderExt.jl
+++ b/ext/TempestRegridderExt.jl
@@ -138,28 +138,20 @@ function reshape_cgll_sparse_to_field!(
     in_array::Array,
     R,
 )
-    field_array = parent(field)
+    target = ClimaCore.Fields.field_values(field)
 
-    fill!(field_array, zero(eltype(field_array)))
-    Nf = size(field_array, 3)
-
+    fill!(target, zero(eltype(target)))
     for (n, row) in enumerate(R.row_indices)
         it, jt, et = (
             view(R.target_idxs[1], n),
             view(R.target_idxs[2], n),
             view(R.target_idxs[3], n),
         )
-        for f in 1:Nf
-            field_array[it, jt, f, et] .= in_array[row]
-        end
+        target[1, it, jt, et] = in_array[row]
     end
 
     # broadcast to the redundant nodes using unweighted dss
-    space = axes(field)
-    topology = ClimaCore.Spaces.topology(space)
-    hspace = ClimaCore.Spaces.horizontal_space(space)
-    target = ClimaCore.Fields.field_values(field)
-
+    topology = ClimaCore.Spaces.topology(axes(field))
     ClimaCore.Topologies.dss!(target, topology)
 end
 


### PR DESCRIPTION
<!--- THESE LINES ARE COMMENTED -->
## Purpose 
This PR updates `TempestRegridderExt.jl` following CliMA/ClimaCore.jl#2522. Every DataLayout used in ClimaAtmos is now a VIJFH, so the parent array manipulation needed to be changed.

<!---
Review checklist

I have:
- followed the codebase contribution guide: https://clima.github.io/ClimateMachine.jl/latest/Contributing/
- followed the style guide: https://clima.github.io/ClimateMachine.jl/latest/DevDocs/CodeStyle/
- followed the documentation policy: https://github.com/CliMA/policies/wiki/Documentation-Policy
- checked that this PR does not duplicate an open PR.

In the Content, I have included 
- relevant unit tests, and integration tests, 
- appropriate docstrings on all functions, structs, and modules, and included relevant documentation.

-->

----
- [x] I have read and checked the items on the review checklist.
